### PR TITLE
Update file suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Automating HandBrake encoding
 
 1. Recursively scans input directory for `.mp4` files to encode
 2. Encodes `.mp4` files with a Constant Frame Rate (CFR) preset
-    - Encoded files are named with the suffix ` - CFR.mp4`
+    - Encoded files are named with the suffix `.cfr.mp4`
     - The preset used is HandBrake's built-in "Production Standard" preset (H.264)
       - It works with any video resolution
       - It works with any framerate

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Automating HandBrake encoding
       - It creates quite a large file afterwards, but it's ideal "as an intermediate format for video editing"
       - I recommend deleting the encoded file after using it, and retaining the original archived file
 3. Archives original videos
-    - Archived files are named with the suffix ` - Archived.mp4`
+    - Archived files are named with the suffix `.archived.mp4`
     - They won't be detected by the program again, if you want to encode again, remove this suffix first
 
 #### Usage:

--- a/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
+++ b/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
@@ -156,12 +156,10 @@ class AppIntegrationTest {
         .containsExactly(
             // encoding
             new PathAndContents(
-                inputDirectory.resolve("League of Legends/ranked_game1.cfr.mp4"),
-                testVideoEncoded),
+                inputDirectory.resolve("League of Legends/ranked_game1.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(
-                inputDirectory.resolve("League of Legends/ranked_game1.archived.mp4"),
-                testVideo));
+                inputDirectory.resolve("League of Legends/ranked_game1.archived.mp4"), testVideo));
   }
 
   @Test
@@ -678,8 +676,7 @@ class AppIntegrationTest {
     // incomplete encodings
     createVideoAt(inputDirectory.resolve("recording1.cfr.mp4.part"), testVideo);
     createVideoAt(
-        inputDirectory.resolve("Nested1/Nested2/Nested3/other video.cfr.mp4.part"),
-        testVideo);
+        inputDirectory.resolve("Nested1/Nested2/Nested3/other video.cfr.mp4.part"), testVideo);
 
     // incomplete archives
     createVideoAt(inputDirectory.resolve("recording2.archived.mp4.part"), testVideo);
@@ -721,8 +718,7 @@ class AppIntegrationTest {
             new PathAndContents(
                 inputDirectory.resolve("Starcraft II/protoss.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                inputDirectory.resolve("Starcraft II/Campaign/terran1.cfr.mp4"),
-                testVideoEncoded),
+                inputDirectory.resolve("Starcraft II/Campaign/terran1.cfr.mp4"), testVideoEncoded),
             // unrelated archives
             new PathAndContents(
                 inputDirectory.resolve("League of Legends/ryze.archived.mp4"), testVideo),

--- a/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
+++ b/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
@@ -67,7 +67,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
@@ -89,7 +89,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo));
   }
@@ -111,7 +111,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(inputDirectory.resolve("vid1 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("vid1.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(archiveDirectory.resolve("vid1 - Archived.mp4"), testVideo));
   }
@@ -135,7 +135,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo));
   }
@@ -156,7 +156,7 @@ class AppIntegrationTest {
         .containsExactly(
             // encoding
             new PathAndContents(
-                inputDirectory.resolve("League of Legends/ranked_game1 - CFR.mp4"),
+                inputDirectory.resolve("League of Legends/ranked_game1.cfr.mp4"),
                 testVideoEncoded),
             // archive
             new PathAndContents(
@@ -182,7 +182,7 @@ class AppIntegrationTest {
         .containsExactly(
             // encoding
             new PathAndContents(
-                outputDirectory.resolve("StarCraft II/protoss - CFR.mp4"), testVideoEncoded),
+                outputDirectory.resolve("StarCraft II/protoss.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(
                 inputDirectory.resolve("StarCraft II/protoss - Archived.mp4"), testVideo));
@@ -206,7 +206,7 @@ class AppIntegrationTest {
         .containsExactly(
             // encoding
             new PathAndContents(
-                inputDirectory.resolve("Path of Exile/vaal spark templar - CFR.mp4"),
+                inputDirectory.resolve("Path of Exile/vaal spark templar.cfr.mp4"),
                 testVideoEncoded),
             // archive
             new PathAndContents(
@@ -236,7 +236,7 @@ class AppIntegrationTest {
         .containsExactly(
             // encoding
             new PathAndContents(
-                outputDirectory.resolve("Halo Infinite/Legendary Campaign/1st mission - CFR.mp4"),
+                outputDirectory.resolve("Halo Infinite/Legendary Campaign/1st mission.cfr.mp4"),
                 testVideoEncoded),
             // archive
             new PathAndContents(
@@ -263,12 +263,12 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            new PathAndContents(inputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
             new PathAndContents(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo),
             new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo),
@@ -298,12 +298,12 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+                outputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
+                outputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
             new PathAndContents(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo),
             new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo),
@@ -333,12 +333,12 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            new PathAndContents(inputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
             new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo),
             new PathAndContents(archiveDirectory.resolve("recording2 - Archived.mp4"), testVideo),
@@ -371,12 +371,12 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+                outputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
+                outputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
             new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo),
             new PathAndContents(archiveDirectory.resolve("recording2 - Archived.mp4"), testVideo),
@@ -409,7 +409,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
@@ -445,7 +445,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(outputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(archiveDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
@@ -459,8 +459,8 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
-    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded);
 
     // unrelated archives
     createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
@@ -473,12 +473,12 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo),
             // unrelated encodings
-            new PathAndContents(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
             // unrelated archives
             new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo),
             new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo));
@@ -499,9 +499,9 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
-    createVideoAt(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
-    createVideoAt(archiveDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);
+    createVideoAt(outputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);
+    createVideoAt(archiveDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);
 
     // unrelated archives
     createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
@@ -515,13 +515,13 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(outputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(archiveDirectory.resolve("my video - Archived.mp4"), testVideo),
             // unrelated encodings
-            new PathAndContents(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(archiveDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(archiveDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             // unrelated archives
             new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo),
             new PathAndContents(outputDirectory.resolve("recording - Archived.mp4"), testVideo),
@@ -537,7 +537,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -546,7 +546,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
@@ -569,7 +569,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
@@ -583,7 +583,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded);
 
     // already archived
     createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo);
@@ -595,7 +595,7 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
   }
@@ -620,7 +620,7 @@ class AppIntegrationTest {
             // original
             new PathAndContents(inputDirectory.resolve("my video.mp4"), testVideo),
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo2));
   }
@@ -635,7 +635,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded);
 
     // already archived but different contents
     createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo2);
@@ -649,7 +649,7 @@ class AppIntegrationTest {
             // original
             new PathAndContents(inputDirectory.resolve("my video.mp4"), testVideo),
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo2));
   }
@@ -668,8 +668,8 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), testVideo);
 
     // already encoded
-    createVideoAt(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded);
-    createVideoAt(inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded);
 
     // already archived
     createVideoAt(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo);
@@ -688,9 +688,9 @@ class AppIntegrationTest {
         testVideo);
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("Starcraft II/protoss - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("Starcraft II/protoss.cfr.mp4"), testVideoEncoded);
     createVideoAt(
-        inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"), testVideoEncoded);
+        inputDirectory.resolve("Starcraft II/Campaign/terran1.cfr.mp4"), testVideoEncoded);
 
     // unrelated archives
     createVideoAt(inputDirectory.resolve("League of Legends/ryze - Archived.mp4"), testVideo);
@@ -704,12 +704,12 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            new PathAndContents(inputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(inputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                inputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                inputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
             new PathAndContents(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo),
             new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo),
@@ -719,9 +719,9 @@ class AppIntegrationTest {
                 inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo),
             // unrelated encodings
             new PathAndContents(
-                inputDirectory.resolve("Starcraft II/protoss - CFR.mp4"), testVideoEncoded),
+                inputDirectory.resolve("Starcraft II/protoss.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                inputDirectory.resolve("Starcraft II/Campaign/terran1 - CFR.mp4"),
+                inputDirectory.resolve("Starcraft II/Campaign/terran1.cfr.mp4"),
                 testVideoEncoded),
             // unrelated archives
             new PathAndContents(
@@ -749,8 +749,8 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // already encoded
-    createVideoAt(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded);
-    createVideoAt(outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded);
+    createVideoAt(outputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded);
+    createVideoAt(outputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded);
 
     // already archived
     createVideoAt(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo);
@@ -767,9 +767,9 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
 
     // unrelated encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
-    createVideoAt(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
-    createVideoAt(archiveDirectory.resolve("recording - CFR.mp4"), testVideoEncoded);
+    createVideoAt(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);
+    createVideoAt(outputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);
+    createVideoAt(archiveDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);
 
     // unrelated archives
     createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
@@ -783,12 +783,12 @@ class AppIntegrationTest {
     assertThatTestDirectory()
         .containsExactly(
             // encodings
-            new PathAndContents(outputDirectory.resolve("recording1 - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(outputDirectory.resolve("recording2 - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                outputDirectory.resolve("Nested/recording3 - CFR.mp4"), testVideoEncoded),
+                outputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded),
             new PathAndContents(
-                outputDirectory.resolve("Nested1/Nested2/recording4 - CFR.mp4"), testVideoEncoded),
+                outputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
             new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo),
             new PathAndContents(archiveDirectory.resolve("recording2 - Archived.mp4"), testVideo),
@@ -797,9 +797,9 @@ class AppIntegrationTest {
             new PathAndContents(
                 archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo),
             // unrelated encodings
-            new PathAndContents(inputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(outputDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
-            new PathAndContents(archiveDirectory.resolve("recording - CFR.mp4"), testVideoEncoded),
+            new PathAndContents(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(outputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
+            new PathAndContents(archiveDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             // unrelated archives
             new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo),
             new PathAndContents(outputDirectory.resolve("recording - Archived.mp4"), testVideo),

--- a/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
+++ b/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
@@ -69,7 +69,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("my video.archived.mp4"), testVideo));
   }
 
   @Test
@@ -91,7 +91,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(outputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("recording.archived.mp4"), testVideo));
   }
 
   @Test
@@ -113,7 +113,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("vid1.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(archiveDirectory.resolve("vid1 - Archived.mp4"), testVideo));
+            new PathAndContents(archiveDirectory.resolve("vid1.archived.mp4"), testVideo));
   }
 
   @Test
@@ -137,7 +137,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(outputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo));
+            new PathAndContents(archiveDirectory.resolve("recording1.archived.mp4"), testVideo));
   }
 
   @Test
@@ -160,7 +160,7 @@ class AppIntegrationTest {
                 testVideoEncoded),
             // archive
             new PathAndContents(
-                inputDirectory.resolve("League of Legends/ranked_game1 - Archived.mp4"),
+                inputDirectory.resolve("League of Legends/ranked_game1.archived.mp4"),
                 testVideo));
   }
 
@@ -185,7 +185,7 @@ class AppIntegrationTest {
                 outputDirectory.resolve("StarCraft II/protoss.cfr.mp4"), testVideoEncoded),
             // archive
             new PathAndContents(
-                inputDirectory.resolve("StarCraft II/protoss - Archived.mp4"), testVideo));
+                inputDirectory.resolve("StarCraft II/protoss.archived.mp4"), testVideo));
   }
 
   @Test
@@ -210,7 +210,7 @@ class AppIntegrationTest {
                 testVideoEncoded),
             // archive
             new PathAndContents(
-                archiveDirectory.resolve("Path of Exile/vaal spark templar - Archived.mp4"),
+                archiveDirectory.resolve("Path of Exile/vaal spark templar.archived.mp4"),
                 testVideo));
   }
 
@@ -241,7 +241,7 @@ class AppIntegrationTest {
             // archive
             new PathAndContents(
                 archiveDirectory.resolve(
-                    "Halo Infinite/Legendary Campaign/1st mission - Archived.mp4"),
+                    "Halo Infinite/Legendary Campaign/1st mission.archived.mp4"),
                 testVideo));
   }
 
@@ -270,12 +270,12 @@ class AppIntegrationTest {
             new PathAndContents(
                 inputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
-            new PathAndContents(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo),
-            new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording1.archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording2.archived.mp4"), testVideo),
             new PathAndContents(
-                inputDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+                inputDirectory.resolve("Nested/recording3.archived.mp4"), testVideo),
             new PathAndContents(
-                inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo));
+                inputDirectory.resolve("Nested1/Nested2/recording4.archived.mp4"), testVideo));
   }
 
   @Test
@@ -305,12 +305,12 @@ class AppIntegrationTest {
             new PathAndContents(
                 outputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
-            new PathAndContents(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo),
-            new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording1.archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording2.archived.mp4"), testVideo),
             new PathAndContents(
-                inputDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+                inputDirectory.resolve("Nested/recording3.archived.mp4"), testVideo),
             new PathAndContents(
-                inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo));
+                inputDirectory.resolve("Nested1/Nested2/recording4.archived.mp4"), testVideo));
   }
 
   @Test
@@ -340,12 +340,12 @@ class AppIntegrationTest {
             new PathAndContents(
                 inputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
-            new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo),
-            new PathAndContents(archiveDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording1.archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording2.archived.mp4"), testVideo),
             new PathAndContents(
-                archiveDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+                archiveDirectory.resolve("Nested/recording3.archived.mp4"), testVideo),
             new PathAndContents(
-                archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo));
+                archiveDirectory.resolve("Nested1/Nested2/recording4.archived.mp4"), testVideo));
   }
 
   @Test
@@ -378,12 +378,12 @@ class AppIntegrationTest {
             new PathAndContents(
                 outputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
-            new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo),
-            new PathAndContents(archiveDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording1.archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording2.archived.mp4"), testVideo),
             new PathAndContents(
-                archiveDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+                archiveDirectory.resolve("Nested/recording3.archived.mp4"), testVideo),
             new PathAndContents(
-                archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo));
+                archiveDirectory.resolve("Nested1/Nested2/recording4.archived.mp4"), testVideo));
   }
 
   @Test
@@ -411,7 +411,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("my video.archived.mp4"), testVideo));
   }
 
   @Test
@@ -447,7 +447,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(outputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(archiveDirectory.resolve("my video - Archived.mp4"), testVideo));
+            new PathAndContents(archiveDirectory.resolve("my video.archived.mp4"), testVideo));
   }
 
   @Test
@@ -463,8 +463,8 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded);
 
     // unrelated archives
-    createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
-    createVideoAt(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording.archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -475,13 +475,13 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("my video.archived.mp4"), testVideo),
             // unrelated encodings
             new PathAndContents(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             new PathAndContents(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
             // unrelated archives
-            new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo),
-            new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("recording.archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording2.archived.mp4"), testVideo));
   }
 
   @Test
@@ -504,9 +504,9 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);
 
     // unrelated archives
-    createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
-    createVideoAt(outputDirectory.resolve("recording - Archived.mp4"), testVideo);
-    createVideoAt(archiveDirectory.resolve("recording - Archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording.archived.mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording.archived.mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording.archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, outputDirectory, archiveDirectory);
@@ -517,15 +517,15 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(outputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(archiveDirectory.resolve("my video - Archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("my video.archived.mp4"), testVideo),
             // unrelated encodings
             new PathAndContents(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             new PathAndContents(outputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             new PathAndContents(archiveDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             // unrelated archives
-            new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo),
-            new PathAndContents(outputDirectory.resolve("recording - Archived.mp4"), testVideo),
-            new PathAndContents(archiveDirectory.resolve("recording - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("recording.archived.mp4"), testVideo),
+            new PathAndContents(outputDirectory.resolve("recording.archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording.archived.mp4"), testVideo));
   }
 
   @Test
@@ -548,7 +548,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("my video.archived.mp4"), testVideo));
   }
 
   @Test
@@ -560,7 +560,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already archived
-    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("my video.archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -571,7 +571,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("my video.archived.mp4"), testVideo));
   }
 
   @Test
@@ -586,7 +586,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded);
 
     // already archived
-    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("my video.archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -597,7 +597,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("my video.archived.mp4"), testVideo));
   }
 
   @Test
@@ -609,7 +609,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // already archived but different contents
-    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo2);
+    createVideoAt(inputDirectory.resolve("my video.archived.mp4"), testVideo2);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -622,7 +622,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo2));
+            new PathAndContents(inputDirectory.resolve("my video.archived.mp4"), testVideo2));
   }
 
   @Test
@@ -638,7 +638,7 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded);
 
     // already archived but different contents
-    createVideoAt(inputDirectory.resolve("my video - Archived.mp4"), testVideo2);
+    createVideoAt(inputDirectory.resolve("my video.archived.mp4"), testVideo2);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -651,7 +651,7 @@ class AppIntegrationTest {
             // encoding
             new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
-            new PathAndContents(inputDirectory.resolve("my video - Archived.mp4"), testVideo2));
+            new PathAndContents(inputDirectory.resolve("my video.archived.mp4"), testVideo2));
   }
 
   @Test
@@ -672,8 +672,8 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded);
 
     // already archived
-    createVideoAt(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo);
-    createVideoAt(inputDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording1.archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("Nested/recording3.archived.mp4"), testVideo);
 
     // incomplete encodings
     createVideoAt(inputDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
@@ -693,9 +693,9 @@ class AppIntegrationTest {
         inputDirectory.resolve("Starcraft II/Campaign/terran1.cfr.mp4"), testVideoEncoded);
 
     // unrelated archives
-    createVideoAt(inputDirectory.resolve("League of Legends/ryze - Archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("League of Legends/ryze.archived.mp4"), testVideo);
     createVideoAt(
-        inputDirectory.resolve("Path of Exile/Old builds/Discharge CoC - Archived.mp4"), testVideo);
+        inputDirectory.resolve("Path of Exile/Old builds/Discharge CoC.archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -711,12 +711,12 @@ class AppIntegrationTest {
             new PathAndContents(
                 inputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
-            new PathAndContents(inputDirectory.resolve("recording1 - Archived.mp4"), testVideo),
-            new PathAndContents(inputDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording1.archived.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("recording2.archived.mp4"), testVideo),
             new PathAndContents(
-                inputDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+                inputDirectory.resolve("Nested/recording3.archived.mp4"), testVideo),
             new PathAndContents(
-                inputDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo),
+                inputDirectory.resolve("Nested1/Nested2/recording4.archived.mp4"), testVideo),
             // unrelated encodings
             new PathAndContents(
                 inputDirectory.resolve("Starcraft II/protoss.cfr.mp4"), testVideoEncoded),
@@ -725,9 +725,9 @@ class AppIntegrationTest {
                 testVideoEncoded),
             // unrelated archives
             new PathAndContents(
-                inputDirectory.resolve("League of Legends/ryze - Archived.mp4"), testVideo),
+                inputDirectory.resolve("League of Legends/ryze.archived.mp4"), testVideo),
             new PathAndContents(
-                inputDirectory.resolve("Path of Exile/Old builds/Discharge CoC - Archived.mp4"),
+                inputDirectory.resolve("Path of Exile/Old builds/Discharge CoC.archived.mp4"),
                 testVideo));
   }
 
@@ -753,8 +753,8 @@ class AppIntegrationTest {
     createVideoAt(outputDirectory.resolve("Nested/recording3.cfr.mp4"), testVideoEncoded);
 
     // already archived
-    createVideoAt(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo);
-    createVideoAt(archiveDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording1.archived.mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("Nested/recording3.archived.mp4"), testVideo);
 
     // incomplete encodings
     createVideoAt(inputDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
@@ -772,9 +772,9 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);
 
     // unrelated archives
-    createVideoAt(inputDirectory.resolve("recording - Archived.mp4"), testVideo);
-    createVideoAt(outputDirectory.resolve("recording - Archived.mp4"), testVideo);
-    createVideoAt(archiveDirectory.resolve("recording - Archived.mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording.archived.mp4"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording.archived.mp4"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording.archived.mp4"), testVideo);
 
     // When
     runApp(inputDirectory, outputDirectory, archiveDirectory);
@@ -790,20 +790,20 @@ class AppIntegrationTest {
             new PathAndContents(
                 outputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
-            new PathAndContents(archiveDirectory.resolve("recording1 - Archived.mp4"), testVideo),
-            new PathAndContents(archiveDirectory.resolve("recording2 - Archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording1.archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording2.archived.mp4"), testVideo),
             new PathAndContents(
-                archiveDirectory.resolve("Nested/recording3 - Archived.mp4"), testVideo),
+                archiveDirectory.resolve("Nested/recording3.archived.mp4"), testVideo),
             new PathAndContents(
-                archiveDirectory.resolve("Nested1/Nested2/recording4 - Archived.mp4"), testVideo),
+                archiveDirectory.resolve("Nested1/Nested2/recording4.archived.mp4"), testVideo),
             // unrelated encodings
             new PathAndContents(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             new PathAndContents(outputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             new PathAndContents(archiveDirectory.resolve("recording.cfr.mp4"), testVideoEncoded),
             // unrelated archives
-            new PathAndContents(inputDirectory.resolve("recording - Archived.mp4"), testVideo),
-            new PathAndContents(outputDirectory.resolve("recording - Archived.mp4"), testVideo),
-            new PathAndContents(archiveDirectory.resolve("recording - Archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("recording.archived.mp4"), testVideo),
+            new PathAndContents(outputDirectory.resolve("recording.archived.mp4"), testVideo),
+            new PathAndContents(archiveDirectory.resolve("recording.archived.mp4"), testVideo));
   }
 
   @CanIgnoreReturnValue

--- a/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
+++ b/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
@@ -399,8 +399,8 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("recording2.cfr.mp4.part"), testVideo);
 
     // incomplete archives
-    createVideoAt(inputDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
-    createVideoAt(inputDirectory.resolve("vid2 - Archived (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("vid.archived.mp4.part"), testVideo);
+    createVideoAt(inputDirectory.resolve("vid2.archived.mp4.part"), testVideo);
 
     // When
     runApp(inputDirectory, inputDirectory, inputDirectory);
@@ -434,9 +434,9 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("recording.cfr.mp4.part"), testVideo);
 
     // incomplete archives
-    createVideoAt(inputDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
-    createVideoAt(outputDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
-    createVideoAt(archiveDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("vid.archived.mp4.part"), testVideo);
+    createVideoAt(outputDirectory.resolve("vid.archived.mp4.part"), testVideo);
+    createVideoAt(archiveDirectory.resolve("vid.archived.mp4.part"), testVideo);
 
     // When
     runApp(inputDirectory, outputDirectory, archiveDirectory);
@@ -682,9 +682,9 @@ class AppIntegrationTest {
         testVideo);
 
     // incomplete archives
-    createVideoAt(inputDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.archived.mp4.part"), testVideo);
     createVideoAt(
-        inputDirectory.resolve("Nested1/Nested2/Nested3/random video - Archived (incomplete).mp4"),
+        inputDirectory.resolve("Nested1/Nested2/Nested3/random video.archived.mp4.part"),
         testVideo);
 
     // unrelated encodings
@@ -762,9 +762,9 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("recording1.cfr.mp4.part"), testVideo);
 
     // incomplete archives
-    createVideoAt(inputDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
-    createVideoAt(outputDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
-    createVideoAt(archiveDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.archived.mp4.part"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording2.archived.mp4.part"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording2.archived.mp4.part"), testVideo);
 
     // unrelated encodings
     createVideoAt(inputDirectory.resolve("recording.cfr.mp4"), testVideoEncoded);

--- a/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
+++ b/nvidia-shadowplay/src/integrationTest/java/com/willmolloy/handbrake/nvidia/shadowplay/AppIntegrationTest.java
@@ -395,8 +395,8 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // incomplete encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR (incomplete).mp4"), testVideo);
-    createVideoAt(inputDirectory.resolve("recording2 - CFR (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording.cfr.mp4.part"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording2.cfr.mp4.part"), testVideo);
 
     // incomplete archives
     createVideoAt(inputDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
@@ -429,9 +429,9 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // incomplete encodings
-    createVideoAt(inputDirectory.resolve("recording - CFR (incomplete).mp4"), testVideo);
-    createVideoAt(outputDirectory.resolve("recording - CFR (incomplete).mp4"), testVideo);
-    createVideoAt(archiveDirectory.resolve("recording - CFR (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording.cfr.mp4.part"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording.cfr.mp4.part"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording.cfr.mp4.part"), testVideo);
 
     // incomplete archives
     createVideoAt(inputDirectory.resolve("vid - Archived (incomplete).mp4"), testVideo);
@@ -676,9 +676,9 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("Nested/recording3.archived.mp4"), testVideo);
 
     // incomplete encodings
-    createVideoAt(inputDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording1.cfr.mp4.part"), testVideo);
     createVideoAt(
-        inputDirectory.resolve("Nested1/Nested2/Nested3/other video - CFR (incomplete).mp4"),
+        inputDirectory.resolve("Nested1/Nested2/Nested3/other video.cfr.mp4.part"),
         testVideo);
 
     // incomplete archives
@@ -757,9 +757,9 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("Nested/recording3.archived.mp4"), testVideo);
 
     // incomplete encodings
-    createVideoAt(inputDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
-    createVideoAt(outputDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
-    createVideoAt(archiveDirectory.resolve("recording1 - CFR (incomplete).mp4"), testVideo);
+    createVideoAt(inputDirectory.resolve("recording1.cfr.mp4.part"), testVideo);
+    createVideoAt(outputDirectory.resolve("recording1.cfr.mp4.part"), testVideo);
+    createVideoAt(archiveDirectory.resolve("recording1.cfr.mp4.part"), testVideo);
 
     // incomplete archives
     createVideoAt(inputDirectory.resolve("recording2 - Archived (incomplete).mp4"), testVideo);

--- a/nvidia-shadowplay/src/main/java/com/willmolloy/handbrake/adhoc/FileRenamer.java
+++ b/nvidia-shadowplay/src/main/java/com/willmolloy/handbrake/adhoc/FileRenamer.java
@@ -62,7 +62,7 @@ public class FileRenamer {
   //      //      fileRenamer.changeSuffixes(directory, " - Archived.mp4", ".mp4");
   //
   //      // other
-  //      //      fileRenamer.changeSuffixes(directory, " - CFR 60 FPS.mp4", " - CFR.mp4");
+  //      //      fileRenamer.changeSuffixes(directory, " - CFR 60 FPS.mp4", ".cfr.mp4");
   //    } catch (Exception e) {
   //      log.fatal("Fatal error", e);
   //    }

--- a/nvidia-shadowplay/src/main/java/com/willmolloy/handbrake/adhoc/FileRenamer.java
+++ b/nvidia-shadowplay/src/main/java/com/willmolloy/handbrake/adhoc/FileRenamer.java
@@ -59,7 +59,7 @@ public class FileRenamer {
   //      FileRenamer fileRenamer = new FileRenamer();
   //
   //      // unarchive
-  //      //      fileRenamer.changeSuffixes(directory, " - Archived.mp4", ".mp4");
+  //      //      fileRenamer.changeSuffixes(directory, ".archived.mp4", ".mp4");
   //
   //      // other
   //      //      fileRenamer.changeSuffixes(directory, " - CFR 60 FPS.mp4", ".cfr.mp4");

--- a/nvidia-shadowplay/src/main/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideo.java
+++ b/nvidia-shadowplay/src/main/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideo.java
@@ -59,10 +59,10 @@ final class UnencodedVideo {
   }
 
   private static final String MP4_SUFFIX = ".mp4";
-  private static final String ENCODED_SUFFIX = " - CFR.mp4";
-  private static final String TEMP_ENCODED_SUFFIX = " - CFR (incomplete).mp4";
-  private static final String ARCHIVED_SUFFIX = " - Archived.mp4";
-  private static final String TEMP_ARCHIVED_SUFFIX = " - Archived (incomplete).mp4";
+  private static final String ENCODED_SUFFIX = ".cfr.mp4";
+  private static final String TEMP_ENCODED_SUFFIX = ".cfr.mp4.part";
+  private static final String ARCHIVED_SUFFIX = ".archived.mp4";
+  private static final String TEMP_ARCHIVED_SUFFIX = ".archived.mp4.part";
 
   public static boolean isMp4(Path path) {
     return fileName(path).endsWith(MP4_SUFFIX);

--- a/nvidia-shadowplay/src/main/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideo.java
+++ b/nvidia-shadowplay/src/main/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideo.java
@@ -115,21 +115,23 @@ final class UnencodedVideo {
     }
 
     public UnencodedVideo newUnencodedVideo(Path videoPath) {
-      checkArgument(isMp4(videoPath), "videoPath (%s) does not represent an .mp4 file", videoPath);
-
-      checkArgument(
-          !isEncodedMp4(videoPath), "videoPath (%s) represents an encoded .mp4 file", videoPath);
       checkArgument(
           !isTempEncodedMp4(videoPath),
           "videoPath (%s) represents an incomplete encoded .mp4 file",
           videoPath);
 
       checkArgument(
-          !isArchivedMp4(videoPath), "videoPath (%s) represents an archived .mp4 file", videoPath);
-      checkArgument(
           !isTempArchivedMp4(videoPath),
           "videoPath (%s) represents an incomplete archived .mp4 file",
           videoPath);
+
+      checkArgument(isMp4(videoPath), "videoPath (%s) does not represent an .mp4 file", videoPath);
+
+      checkArgument(
+          !isEncodedMp4(videoPath), "videoPath (%s) represents an encoded .mp4 file", videoPath);
+
+      checkArgument(
+          !isArchivedMp4(videoPath), "videoPath (%s) represents an archived .mp4 file", videoPath);
 
       checkArgument(
           videoPath.startsWith(inputDirectory),

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/adhoc/FileRenamerTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/adhoc/FileRenamerTest.java
@@ -56,12 +56,12 @@ class FileRenamerTest {
   void ignoresFilesNotMatchingSuffix() throws IOException {
     // Given
     Files.createDirectories(testDirectory.resolve("Nested"));
-    Files.createFile(testDirectory.resolve("video1 - Archived.mp4"));
+    Files.createFile(testDirectory.resolve("video1.archived.mp4"));
     Files.createFile(testDirectory.resolve("My Vid2 - New.mp4"));
     Files.createFile(testDirectory.resolve("Nested/Video3.mp4"));
 
     // When
-    fileRenamer.changeSuffixes(testDirectory, " - Archived.mp4", ".mp4");
+    fileRenamer.changeSuffixes(testDirectory, ".archived.mp4", ".mp4");
 
     // Then
     assertThat(Files.walk(testDirectory).filter(Files::isRegularFile))

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/AppTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/AppTest.java
@@ -126,7 +126,7 @@ class AppTest {
   @Test
   void deletesIncompleteEncodings() throws Exception {
     // Given
-    Files.copy(testVideo, outputDirectory.resolve("video1 - CFR (incomplete).mp4"));
+    Files.copy(testVideo, outputDirectory.resolve("video1.cfr.mp4.part"));
 
     // When
     app.run(inputDirectory, outputDirectory, archiveDirectory);

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/AppTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/AppTest.java
@@ -138,7 +138,7 @@ class AppTest {
   @Test
   void deletesIncompleteArchives() throws Exception {
     // Given
-    Files.copy(testVideo, archiveDirectory.resolve("video1 - Archived (incomplete).mp4"));
+    Files.copy(testVideo, archiveDirectory.resolve("video1.archived.mp4.part"));
 
     // When
     app.run(inputDirectory, outputDirectory, archiveDirectory);

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideoTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideoTest.java
@@ -61,7 +61,7 @@ class UnencodedVideoTest {
         .isEqualTo(outputDirectory.resolve("file - CFR (incomplete).mp4"));
 
     assertThat(unencodedVideo.archivedPath())
-        .isEqualTo(archiveDirectory.resolve("file - Archived.mp4"));
+        .isEqualTo(archiveDirectory.resolve("file.archived.mp4"));
     assertThat(unencodedVideo.tempArchivedPath())
         .isEqualTo(archiveDirectory.resolve("file - Archived (incomplete).mp4"));
   }
@@ -83,7 +83,7 @@ class UnencodedVideoTest {
         .isEqualTo(outputDirectory.resolve("Nested/Nested2/file - CFR (incomplete).mp4"));
 
     assertThat(unencodedVideo.archivedPath())
-        .isEqualTo(archiveDirectory.resolve("Nested/Nested2/file - Archived.mp4"));
+        .isEqualTo(archiveDirectory.resolve("Nested/Nested2/file.archived.mp4"));
     assertThat(unencodedVideo.tempArchivedPath())
         .isEqualTo(archiveDirectory.resolve("Nested/Nested2/file - Archived (incomplete).mp4"));
   }
@@ -134,7 +134,7 @@ class UnencodedVideoTest {
   @Test
   void factory_newUnencodedVideo_rejectsArchivedMp4File() {
     // Given
-    Path archivedMp4File = inputDirectory.resolve("file - Archived.mp4");
+    Path archivedMp4File = inputDirectory.resolve("file.archived.mp4");
 
     // When & Then
     IllegalArgumentException thrown =

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideoTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideoTest.java
@@ -56,7 +56,7 @@ class UnencodedVideoTest {
     // Then
     assertThat(unencodedVideo.originalPath()).isSameInstanceAs(mp4File);
 
-    assertThat(unencodedVideo.encodedPath()).isEqualTo(outputDirectory.resolve("file - CFR.mp4"));
+    assertThat(unencodedVideo.encodedPath()).isEqualTo(outputDirectory.resolve("file.cfr.mp4"));
     assertThat(unencodedVideo.tempEncodedPath())
         .isEqualTo(outputDirectory.resolve("file - CFR (incomplete).mp4"));
 
@@ -78,7 +78,7 @@ class UnencodedVideoTest {
     assertThat(unencodedVideo.originalPath()).isSameInstanceAs(mp4File);
 
     assertThat(unencodedVideo.encodedPath())
-        .isEqualTo(outputDirectory.resolve("Nested/Nested2/file - CFR.mp4"));
+        .isEqualTo(outputDirectory.resolve("Nested/Nested2/file.cfr.mp4"));
     assertThat(unencodedVideo.tempEncodedPath())
         .isEqualTo(outputDirectory.resolve("Nested/Nested2/file - CFR (incomplete).mp4"));
 
@@ -104,7 +104,7 @@ class UnencodedVideoTest {
   @Test
   void factory_newUnencodedVideo_rejectsEncodedMp4File() {
     // Given
-    Path encodedMp4File = inputDirectory.resolve("file - CFR.mp4");
+    Path encodedMp4File = inputDirectory.resolve("file.cfr.mp4");
 
     // When & Then
     IllegalArgumentException thrown =

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideoTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideoTest.java
@@ -58,7 +58,7 @@ class UnencodedVideoTest {
 
     assertThat(unencodedVideo.encodedPath()).isEqualTo(outputDirectory.resolve("file.cfr.mp4"));
     assertThat(unencodedVideo.tempEncodedPath())
-        .isEqualTo(outputDirectory.resolve("file - CFR (incomplete).mp4"));
+        .isEqualTo(outputDirectory.resolve("file.cfr.mp4.part"));
 
     assertThat(unencodedVideo.archivedPath())
         .isEqualTo(archiveDirectory.resolve("file.archived.mp4"));
@@ -80,7 +80,7 @@ class UnencodedVideoTest {
     assertThat(unencodedVideo.encodedPath())
         .isEqualTo(outputDirectory.resolve("Nested/Nested2/file.cfr.mp4"));
     assertThat(unencodedVideo.tempEncodedPath())
-        .isEqualTo(outputDirectory.resolve("Nested/Nested2/file - CFR (incomplete).mp4"));
+        .isEqualTo(outputDirectory.resolve("Nested/Nested2/file.cfr.mp4.part"));
 
     assertThat(unencodedVideo.archivedPath())
         .isEqualTo(archiveDirectory.resolve("Nested/Nested2/file.archived.mp4"));
@@ -118,7 +118,7 @@ class UnencodedVideoTest {
   @Test
   void factory_newUnencodedVideo_rejectsTempEncodedMp4File() {
     // Given
-    Path tempEncodedMp4File = inputDirectory.resolve("file - CFR (incomplete).mp4");
+    Path tempEncodedMp4File = inputDirectory.resolve("file.cfr.mp4.part");
 
     // When & Then
     IllegalArgumentException thrown =

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideoTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/UnencodedVideoTest.java
@@ -63,7 +63,7 @@ class UnencodedVideoTest {
     assertThat(unencodedVideo.archivedPath())
         .isEqualTo(archiveDirectory.resolve("file.archived.mp4"));
     assertThat(unencodedVideo.tempArchivedPath())
-        .isEqualTo(archiveDirectory.resolve("file - Archived (incomplete).mp4"));
+        .isEqualTo(archiveDirectory.resolve("file.archived.mp4.part"));
   }
 
   @Test
@@ -85,7 +85,7 @@ class UnencodedVideoTest {
     assertThat(unencodedVideo.archivedPath())
         .isEqualTo(archiveDirectory.resolve("Nested/Nested2/file.archived.mp4"));
     assertThat(unencodedVideo.tempArchivedPath())
-        .isEqualTo(archiveDirectory.resolve("Nested/Nested2/file - Archived (incomplete).mp4"));
+        .isEqualTo(archiveDirectory.resolve("Nested/Nested2/file.archived.mp4.part"));
   }
 
   @Test
@@ -148,7 +148,7 @@ class UnencodedVideoTest {
   @Test
   void factory_newUnencodedVideo_rejectsTempArchivedMp4File() {
     // Given
-    Path tempArchivedMp4File = inputDirectory.resolve("file - Archived (incomplete).mp4");
+    Path tempArchivedMp4File = inputDirectory.resolve("file.archived.mp4.part");
 
     // When & Then
     IllegalArgumentException thrown =

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/VideoArchiverTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/VideoArchiverTest.java
@@ -62,7 +62,7 @@ class VideoArchiverTest {
     videoArchiver.archiveAsync(unencodedVideo).join();
 
     // Then
-    assertThatTestDirectory().containsExactly(archiveDirectory.resolve("file - Archived.mp4"));
+    assertThatTestDirectory().containsExactly(archiveDirectory.resolve("file.archived.mp4"));
   }
 
   @Test
@@ -79,13 +79,13 @@ class VideoArchiverTest {
 
     // Then
     assertThatTestDirectory()
-        .containsExactly(archiveDirectory.resolve("Halo/Campaign/file - Archived.mp4"));
+        .containsExactly(archiveDirectory.resolve("Halo/Campaign/file.archived.mp4"));
   }
 
   @Test
   void archiveFileAlreadyExistsStillDeletesOriginal() throws IOException {
     // Given
-    Files.copy(testVideo, archiveDirectory.resolve("file - Archived.mp4"));
+    Files.copy(testVideo, archiveDirectory.resolve("file.archived.mp4"));
 
     Path unencodedMp4File = Files.copy(testVideo, inputDirectory.resolve("file.mp4"));
 
@@ -95,13 +95,13 @@ class VideoArchiverTest {
     videoArchiver.archiveAsync(unencodedVideo).join();
 
     // Then
-    assertThatTestDirectory().containsExactly(archiveDirectory.resolve("file - Archived.mp4"));
+    assertThatTestDirectory().containsExactly(archiveDirectory.resolve("file.archived.mp4"));
   }
 
   @Test
   void archiveFileExistsButContentsDifferKeepsOriginal() throws IOException {
     // Given
-    Files.copy(testVideo2, archiveDirectory.resolve("file - Archived.mp4"));
+    Files.copy(testVideo2, archiveDirectory.resolve("file.archived.mp4"));
 
     Path unencodedMp4File = Files.copy(testVideo, inputDirectory.resolve("file.mp4"));
 
@@ -113,7 +113,7 @@ class VideoArchiverTest {
     // Then
     assertThatTestDirectory()
         .containsExactly(
-            inputDirectory.resolve("file.mp4"), archiveDirectory.resolve("file - Archived.mp4"));
+            inputDirectory.resolve("file.mp4"), archiveDirectory.resolve("file.archived.mp4"));
   }
 
   private StreamSubject assertThatTestDirectory() throws IOException {

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/VideoEncoderTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/VideoEncoderTest.java
@@ -83,8 +83,7 @@ class VideoEncoderTest {
     videoEncoder.encode(unencodedVideo);
 
     // Then
-    verify(mockHandBrake)
-        .encode(unencodedMp4File, outputDirectory.resolve("file.cfr.mp4.part"));
+    verify(mockHandBrake).encode(unencodedMp4File, outputDirectory.resolve("file.cfr.mp4.part"));
     assertThatTestDirectory()
         .containsExactly(
             inputDirectory.resolve("file.mp4"), outputDirectory.resolve("file.cfr.mp4"));
@@ -115,8 +114,7 @@ class VideoEncoderTest {
 
     // Then
     verify(mockHandBrake)
-        .encode(
-            unencodedMp4File, outputDirectory.resolve("Halo/Campaign/file.cfr.mp4.part"));
+        .encode(unencodedMp4File, outputDirectory.resolve("Halo/Campaign/file.cfr.mp4.part"));
     assertThatTestDirectory()
         .containsExactly(
             inputDirectory.resolve("Halo/Campaign/file.mp4"),

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/VideoEncoderTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/VideoEncoderTest.java
@@ -84,7 +84,7 @@ class VideoEncoderTest {
 
     // Then
     verify(mockHandBrake)
-        .encode(unencodedMp4File, outputDirectory.resolve("file - CFR (incomplete).mp4"));
+        .encode(unencodedMp4File, outputDirectory.resolve("file.cfr.mp4.part"));
     assertThatTestDirectory()
         .containsExactly(
             inputDirectory.resolve("file.mp4"), outputDirectory.resolve("file.cfr.mp4"));
@@ -116,7 +116,7 @@ class VideoEncoderTest {
     // Then
     verify(mockHandBrake)
         .encode(
-            unencodedMp4File, outputDirectory.resolve("Halo/Campaign/file - CFR (incomplete).mp4"));
+            unencodedMp4File, outputDirectory.resolve("Halo/Campaign/file.cfr.mp4.part"));
     assertThatTestDirectory()
         .containsExactly(
             inputDirectory.resolve("Halo/Campaign/file.mp4"),

--- a/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/VideoEncoderTest.java
+++ b/nvidia-shadowplay/src/test/java/com/willmolloy/handbrake/nvidia/shadowplay/VideoEncoderTest.java
@@ -87,7 +87,7 @@ class VideoEncoderTest {
         .encode(unencodedMp4File, outputDirectory.resolve("file - CFR (incomplete).mp4"));
     assertThatTestDirectory()
         .containsExactly(
-            inputDirectory.resolve("file.mp4"), outputDirectory.resolve("file - CFR.mp4"));
+            inputDirectory.resolve("file.mp4"), outputDirectory.resolve("file.cfr.mp4"));
   }
 
   @Test
@@ -120,7 +120,7 @@ class VideoEncoderTest {
     assertThatTestDirectory()
         .containsExactly(
             inputDirectory.resolve("Halo/Campaign/file.mp4"),
-            outputDirectory.resolve("Halo/Campaign/file - CFR.mp4"));
+            outputDirectory.resolve("Halo/Campaign/file.cfr.mp4"));
   }
 
   @Test
@@ -142,7 +142,7 @@ class VideoEncoderTest {
   @Test
   void encodedFileAlreadyExistsReturnsEarly() throws IOException {
     // Given
-    Files.copy(testVideo, outputDirectory.resolve("file - CFR.mp4"));
+    Files.copy(testVideo, outputDirectory.resolve("file.cfr.mp4"));
 
     Path unencodedMp4File = Files.copy(testVideo, inputDirectory.resolve("file.mp4"));
 
@@ -155,7 +155,7 @@ class VideoEncoderTest {
     verify(mockHandBrake, never()).encode(any(), any());
     assertThatTestDirectory()
         .containsExactly(
-            inputDirectory.resolve("file.mp4"), outputDirectory.resolve("file - CFR.mp4"));
+            inputDirectory.resolve("file.mp4"), outputDirectory.resolve("file.cfr.mp4"));
   }
 
   private StreamSubject assertThatTestDirectory() throws IOException {


### PR DESCRIPTION
Encoded: ` - CFR.mp4` -> `.cfr.mp4`
Archived: ` - Archived.mp4` -> `.archived.mp4`
Temp: ` (incomplete).mp4` -> `.mp4.part`

Reasoning:
- Shorter file names
- Reduce spaces in file names
- `.part` is standard for partial files