### PR TITLE
Containerise

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.4.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,23 @@
+# this workflow verifies the Dockerfile can be built and run
+name: docker
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.4.0
+
+      - name: Build Dockerfile
+        run: docker build -t handbrake .
+
+      - name: Run container
+        run: docker run --rm handbrake

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  docker:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,10 +27,8 @@ jobs:
         # Can't run gradle as root, some reason github actions defaults to Java 11
         # TODO locally this doesn't work??? - still needing to run Java/Gradle with sudo
         run: |
-          sudo add-apt-repository ppa:stebbins/handbrake-releases \
-          && sudo apt-get update \
-          && sudo apt-get install handbrake-cli \
-          && sudo chmod a+x /usr/bin/HandBrakeCLI
+          sudo sudo apt update \
+          && sudo apt install handbrake
 
       - name: Setup HandBrake (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,7 +28,7 @@ jobs:
         # TODO locally this doesn't work??? - still needing to run Java/Gradle with sudo
         run: |
           sudo apt update \
-          && sudo apt install handbrake
+          && sudo apt install handbrake-cli
 
       - name: Setup HandBrake (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Setup HandBrake (Linux)
         if: matrix.os == 'ubuntu-latest'
-        run: apt install handbrake-cli
+        run: sudo apt install handbrake-cli
 
       - name: Setup HandBrake (Windows)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,7 +27,7 @@ jobs:
         # Can't run gradle as root, some reason github actions defaults to Java 11
         # TODO locally this doesn't work??? - still needing to run Java/Gradle with sudo
         run: |
-          sudo sudo apt update \
+          sudo apt update \
           && sudo apt install handbrake
 
       - name: Setup HandBrake (Windows)

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -23,12 +23,7 @@ jobs:
 
       - name: Setup HandBrake (Linux)
         if: matrix.os == 'ubuntu-latest'
-        # Need to install as root, then chmod a+x so non-root Java/Gradle can access HandBrakeCLI
-        # Can't run gradle as root, some reason github actions defaults to Java 11
-        # TODO locally this doesn't work??? - still needing to run Java/Gradle with sudo
-        run: |
-          sudo apt update \
-          && sudo apt install handbrake-cli
+        run: apt install handbrake-cli
 
       - name: Setup HandBrake (Windows)
         if: matrix.os == 'windows-latest'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@
 FROM jlesage/handbrake:latest
 
 # Update packages
-RUN apk update && \
-    apk add --upgrade apk-tools && \
-    apk upgrade --available && \
-    sync
+RUN apk update \
+    && apk add --upgrade apk-tools \
+    && apk upgrade --available \
+    && sync
 
 # Install OpenJDK 17
 RUN apk --no-cache add openjdk17 --repository=https://dl-cdn.alpinelinux.org/alpine/latest-stable/community

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use HandBrake base image (Alpine Linux)
+# Installing it otherwise (i.e. on Java base image) is a pain
+FROM jlesage/handbrake:latest
+
+# Update packages
+RUN apk update && \
+    apk add --upgrade apk-tools && \
+    apk upgrade --available && \
+    sync
+
+# Install OpenJDK 17
+RUN apk --no-cache add openjdk17 --repository=https://dl-cdn.alpinelinux.org/alpine/latest-stable/community
+
+COPY . /app
+WORKDIR /app
+
+RUN ./gradlew build
+
+VOLUME /input
+VOLUME /output
+VOLUME /archive
+
+# TODO remove sleep
+ENTRYPOINT ./gradlew :nvidia-shadowplay:run -PinputDirectory="/input" -PoutputDirectory="/output" -ParchiveDirectory="/archive" && sleep 99999

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk --no-cache add openjdk17 --repository=https://dl-cdn.alpinelinux.org/alp
 COPY . /app
 WORKDIR /app
 
-RUN ./gradlew build
+RUN ./gradlew clean build
 
 VOLUME /input
 VOLUME /output

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,4 @@ VOLUME /input
 VOLUME /output
 VOLUME /archive
 
-# TODO remove sleep
-ENTRYPOINT ./gradlew :nvidia-shadowplay:run -PinputDirectory="/input" -PoutputDirectory="/output" -ParchiveDirectory="/archive" && sleep 99999
+ENTRYPOINT ./gradlew :nvidia-shadowplay:run -PinputDirectory="/input" -PoutputDirectory="/output" -ParchiveDirectory="/archive"

--- a/README.md
+++ b/README.md
@@ -6,18 +6,13 @@
 
 Automating HandBrake encoding
 
-## Requirements
-
-- Java 17
-- HandBrakeCLI
-
 ## Use cases
 
 ### Encoding Nvidia ShadowPlay videos with a CFR preset
 
 #### Why?
 
-- Nvidia ShadowPlay records video with a variable/peak frame rate (PFR), leading to audio sync issues in video editing software
+- Nvidia ShadowPlay records video with a variable/peak frame rate (VFR/PFR), leading to audio sync issues in video editing software
 
 #### How?
 
@@ -35,16 +30,35 @@ Automating HandBrake encoding
 
 #### Usage:
 
-1. Build and test via Gradle:
+You can run with either Gradle directly or with Docker.
+
+The app requires the following arguments:
+- `inputDirectory` directory containing `.mp4` files to encode
+- `outputDirectory` where you want encoded files to be saved
+- `archiveDirectory` where you want archived files to be saved
+- (These can all be the same directory, personally I record and encode to an SSD, then archive to NAS)
+
+##### Run with Gradle (requires Java 17 and HandBrakeCLI installed)
+
+1. Build:
    ```bash
-   ./gradlew build integrationTest
+   ./gradlew build
    ```
 
-2. Run via [Gradle task](nvidia-shadowplay/build.gradle):
+2. Run:
    ```bash
    ./gradlew :nvidia-shadowplay:run -PinputDirectory="" -PoutputDirectory="" -ParchiveDirectory=""
    ```
-    - Set `inputDirectory` to directory containing `.mp4` files to encode
-    - Set `outputDirectory` where you want encoded files to be saved
-    - Set `archiveDirectory` where you want archived files to be saved
-    - (These can all be the same directory, personally I record and encode to an SSD, then archive to NAS)
+
+##### Run with Docker
+
+1. Build:
+   ```bash
+   docker build -t handbrake .
+   ```
+
+2. Run:
+   ```bash
+   docker run --rm -v <INPUT_DIR>:/input -v <OUTPUT_DIR>:/output -v <ARCHIVE_DIR>:/archive handbrake
+   ```
+   - (If you need to mount a network drive, [this stackoverflow answer](https://stackoverflow.com/a/57510166/6122976) worked for me)


### PR DESCRIPTION
- Added `Dockerfile` which has Handbrake, Java and installs the app
- Running this way means local system doesn't need to install Java/Handbrake, isn't polluted with logs, etc.
- Can potentially limit container resources too or run multiple instances at once
- Also means the Handbrake process dies when you kill the container (partially solves #16)