### PR TITLE
Revisit error scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,10 @@ The app requires the following arguments:
    docker run --rm -v <INPUT_DIR>:/input -v <OUTPUT_DIR>:/output -v <ARCHIVE_DIR>:/archive handbrake
    ```
    - (If you need to mount a network drive, [this stackoverflow answer](https://stackoverflow.com/a/57510166/6122976) worked for me)
+
+## Project layout
+
+| Module                                       | Description                                                 |
+|----------------------------------------------|-------------------------------------------------------------|
+| [auto-handbrake-core](./auto-handbrake-core) | Core classes required to run HandBrake via Java             |
+| [auto-handbrake-cfr](./auto-handbrake-cfr)   | CFR conversion, [described above](#converting-to-cfr-video) |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The app requires the following arguments:
 
 ## Project layout
 
-| Module                                       | Description                                                 |
-|----------------------------------------------|-------------------------------------------------------------|
-| [auto-handbrake-core](./auto-handbrake-core) | Core classes required to run HandBrake via Java             |
-| [auto-handbrake-cfr](./auto-handbrake-cfr)   | CFR conversion, [described above](#converting-to-cfr-video) |
+| Module                                       | Description                                                   |
+|----------------------------------------------|---------------------------------------------------------------|
+| [auto-handbrake-core](./auto-handbrake-core) | Core interface and classes required to run HandBrake via Java |
+| [auto-handbrake-cfr](./auto-handbrake-cfr)   | CFR conversion, [described above](#converting-to-cfr-video)   |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Automating HandBrake encoding
       - It works with any framerate
       - It creates quite a large file afterwards, but it's ideal "as an intermediate format for video editing"
       - I recommend deleting the encoded file after using it, and retaining the original archived file
+    - Encoded files are not overwritten, if you want to encode again, delete them first
 3. Archives original videos
     - Archived files are named with the suffix `.archived.mp4`
     - They won't be detected by the program again, if you want to encode again, remove this suffix first

--- a/auto-handbrake-cfr/build.gradle
+++ b/auto-handbrake-cfr/build.gradle
@@ -4,7 +4,7 @@ String archiveDirectory = project.getProperties().getOrDefault("archiveDirectory
 
 task run(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
-  main = 'com.willmolloy.handbrake.cfr.App'
+  main = 'com.willmolloy.handbrake.cfr.Main'
   args = [inputDirectory, outputDirectory, archiveDirectory]
 }
 

--- a/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/AppIntegrationTest.java
+++ b/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/AppIntegrationTest.java
@@ -7,6 +7,7 @@ import com.google.common.io.Resources;
 import com.google.common.truth.Correspondence;
 import com.google.common.truth.IterableSubject;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.willmolloy.handbrake.core.HandBrake;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -22,7 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 /**
- * AppIntegrationTest.
+ * Contains various scenarios testing {@link App} as a black box. Read the logs to understand each scenario further.
  *
  * <p>Requires HandBrakeCLI to be installed.
  *
@@ -54,16 +55,17 @@ class AppIntegrationTest {
 
   @Test
   @Order(0)
-  void singleVideo() throws IOException {
+  void singleVideo() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
     createVideoAt(inputDirectory.resolve("my video.mp4"), testVideo);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -74,7 +76,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(1)
-  void singleVideo_encodeToDifferentDirectory() throws IOException {
+  void singleVideo_encodeToDifferentDirectory() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -83,9 +85,10 @@ class AppIntegrationTest {
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
     // When
-    runApp(inputDirectory, outputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, outputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -96,7 +99,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(2)
-  void singleVideo_archiveToDifferentDirectory() throws IOException {
+  void singleVideo_archiveToDifferentDirectory() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -105,9 +108,10 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // When
-    runApp(inputDirectory, inputDirectory, archiveDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, archiveDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -118,7 +122,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(3)
-  void singleVideo_encodeAndArchiveToDifferentDirectory() throws IOException {
+  void singleVideo_encodeAndArchiveToDifferentDirectory() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -129,9 +133,10 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // When
-    runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -142,16 +147,17 @@ class AppIntegrationTest {
 
   @Test
   @Order(10)
-  void singleVideo_nestedDirectoryStructure() throws IOException {
+  void singleVideo_nestedDirectoryStructure() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
     createVideoAt(inputDirectory.resolve("League of Legends/ranked_game1.mp4"), testVideo);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -164,7 +170,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(11)
-  void singleVideo_nestedDirectoryStructure_encodeToDifferentDirectory() throws IOException {
+  void singleVideo_nestedDirectoryStructure_encodeToDifferentDirectory() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -173,9 +179,10 @@ class AppIntegrationTest {
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
     // When
-    runApp(inputDirectory, outputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, outputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -188,7 +195,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(12)
-  void singleVideo_nestedDirectoryStructure_archiveToDifferentDirectory() throws IOException {
+  void singleVideo_nestedDirectoryStructure_archiveToDifferentDirectory() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -197,9 +204,10 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // When
-    runApp(inputDirectory, inputDirectory, archiveDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, archiveDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -215,7 +223,7 @@ class AppIntegrationTest {
   @Test
   @Order(13)
   void singleVideo_nestedDirectoryStructure_encodeAndArchiveToDifferentDirectory()
-      throws IOException {
+      throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -227,9 +235,10 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // When
-    runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -245,7 +254,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(20)
-  void severalVideos_nestedDirectoryStructure() throws IOException {
+  void severalVideos_nestedDirectoryStructure() throws Exception {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -255,9 +264,10 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), testVideo);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encodings
@@ -278,7 +288,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(21)
-  void severalVideos_nestedDirectoryStructure_encodeToDifferentDirectory() throws IOException {
+  void severalVideos_nestedDirectoryStructure_encodeToDifferentDirectory() throws Exception {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -290,9 +300,10 @@ class AppIntegrationTest {
     Path outputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Encoded"));
 
     // When
-    runApp(inputDirectory, outputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, outputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encodings
@@ -313,7 +324,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(22)
-  void severalVideos_nestedDirectoryStructure_archiveToDifferentDirectory() throws IOException {
+  void severalVideos_nestedDirectoryStructure_archiveToDifferentDirectory() throws Exception {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -325,9 +336,10 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // When
-    runApp(inputDirectory, inputDirectory, archiveDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, archiveDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encodings
@@ -349,7 +361,7 @@ class AppIntegrationTest {
   @Test
   @Order(23)
   void severalVideos_nestedDirectoryStructure_encodeAndArchiveToDifferentDirectory()
-      throws IOException {
+      throws Exception {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -363,9 +375,10 @@ class AppIntegrationTest {
     Path archiveDirectory = createDirectoryAt(testDirectory.resolve("Gameplay Archive"));
 
     // When
-    runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encodings
@@ -386,7 +399,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(30)
-  void singleVideo_and_deletesIncompleteEncodingsAndArchives() throws IOException {
+  void singleVideo_and_deletesIncompleteEncodingsAndArchives() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -401,9 +414,10 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("vid2.archived.mp4.part"), testVideo);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -416,7 +430,7 @@ class AppIntegrationTest {
   @Order(31)
   void
       singleVideo_encodeAndArchiveToDifferentDirectory_and_deletesIncompleteEncodingsAndArchivesInAllDirectories()
-          throws IOException {
+          throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -437,9 +451,10 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("vid.archived.mp4.part"), testVideo);
 
     // When
-    runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -450,7 +465,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(40)
-  void singleVideo_and_retainsCompleteEncodingsAndArchives() throws IOException {
+  void singleVideo_and_retainsCompleteEncodingsAndArchives() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -465,9 +480,10 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("recording2.archived.mp4"), testVideo);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -486,7 +502,7 @@ class AppIntegrationTest {
   @Order(41)
   void
       singleVideo_encodeAndArchiveToDifferentDirectory_and_retainsCompleteEncodingsAndArchivesInAllDirectories()
-          throws IOException {
+          throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -507,9 +523,10 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("recording.archived.mp4"), testVideo);
 
     // When
-    runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -528,7 +545,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(50)
-  void singleVideo_encodingAlreadyExists() throws IOException {
+  void singleVideo_encodingAlreadyExists() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -538,20 +555,21 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isFalse();
     assertThatTestDirectory()
         .containsExactly(
+            // original
+            new PathAndContents(inputDirectory.resolve("my video.mp4"), testVideo),
             // encoding
-            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
-            // archive
-            new PathAndContents(inputDirectory.resolve("my video.archived.mp4"), testVideo));
+            new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded));
   }
 
   @Test
   @Order(51)
-  void singleVideo_archiveAlreadyExists() throws IOException {
+  void singleVideo_archiveAlreadyExists() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -561,9 +579,10 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.archived.mp4"), testVideo);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding
@@ -574,7 +593,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(52)
-  void singleVideo_encodingAndArchiveAlreadyExists() throws IOException {
+  void singleVideo_encodingAndArchiveAlreadyExists() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -587,11 +606,14 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.archived.mp4"), testVideo);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isFalse();
     assertThatTestDirectory()
         .containsExactly(
+            // original
+            new PathAndContents(inputDirectory.resolve("my video.mp4"), testVideo),
             // encoding
             new PathAndContents(inputDirectory.resolve("my video.cfr.mp4"), testVideoEncoded),
             // archive
@@ -600,7 +622,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(60)
-  void singleVideo_archiveExistsButContentsDifferSoRetainsOriginal() throws IOException {
+  void singleVideo_archiveExistsButContentsDiffer() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -610,9 +632,10 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.archived.mp4"), testVideo2);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isFalse();
     assertThatTestDirectory()
         .containsExactly(
             // original
@@ -625,8 +648,8 @@ class AppIntegrationTest {
 
   @Test
   @Order(61)
-  void singleVideo_encodingAlreadyExists_and_archiveExistsButContentsDifferSoRetainsOriginal()
-      throws IOException {
+  void singleVideo_encodingAlreadyExists_and_archiveExistsButContentsDiffer()
+      throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -639,9 +662,10 @@ class AppIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.archived.mp4"), testVideo2);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isFalse();
     assertThatTestDirectory()
         .containsExactly(
             // original
@@ -656,7 +680,7 @@ class AppIntegrationTest {
   @Order(100)
   void
       severalVideos_nestedDirectoryStructure_and_someEncodingsAndArchivesAlreadyExists_and_deletesIncompleteEncodingsAndArchives_and_retainsCompleteEncodingsAndArchives()
-          throws IOException {
+          throws Exception {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -695,11 +719,16 @@ class AppIntegrationTest {
         inputDirectory.resolve("Path of Exile/Old builds/Discharge CoC.archived.mp4"), testVideo);
 
     // When
-    runApp(inputDirectory, inputDirectory, inputDirectory);
+    boolean result = runApp(inputDirectory, inputDirectory, inputDirectory);
 
     // Then
+    assertThat(result).isFalse();
     assertThatTestDirectory()
         .containsExactly(
+            // originals
+            new PathAndContents(inputDirectory.resolve("recording2.mp4"), testVideo),
+            new PathAndContents(
+                inputDirectory.resolve("Nested/recording3.mp4"), testVideo),
             // encodings
             new PathAndContents(inputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
             new PathAndContents(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
@@ -709,7 +738,6 @@ class AppIntegrationTest {
                 inputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
             new PathAndContents(inputDirectory.resolve("recording1.archived.mp4"), testVideo),
-            new PathAndContents(inputDirectory.resolve("recording2.archived.mp4"), testVideo),
             new PathAndContents(
                 inputDirectory.resolve("Nested/recording3.archived.mp4"), testVideo),
             new PathAndContents(
@@ -731,7 +759,7 @@ class AppIntegrationTest {
   @Order(101)
   void
       severalVideos_nestedDirectoryStructure_encodeAndArchiveToDifferentDirectory_and_someEncodingsAndArchivesAlreadyExists_and_deletesIncompleteEncodingsAndArchivesInAllDirectories_and_retainsCompleteEncodingsAndArchivesInAllDirectories()
-          throws IOException {
+          throws Exception {
     // Given
     // videos to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -773,11 +801,16 @@ class AppIntegrationTest {
     createVideoAt(archiveDirectory.resolve("recording.archived.mp4"), testVideo);
 
     // When
-    runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
+    assertThat(result).isFalse();
     assertThatTestDirectory()
         .containsExactly(
+            // originals
+            new PathAndContents(inputDirectory.resolve("recording2.mp4"), testVideo),
+            new PathAndContents(
+                inputDirectory.resolve("Nested/recording3.mp4"), testVideo),
             // encodings
             new PathAndContents(outputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
             new PathAndContents(outputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
@@ -787,7 +820,6 @@ class AppIntegrationTest {
                 outputDirectory.resolve("Nested1/Nested2/recording4.cfr.mp4"), testVideoEncoded),
             // archives
             new PathAndContents(archiveDirectory.resolve("recording1.archived.mp4"), testVideo),
-            new PathAndContents(archiveDirectory.resolve("recording2.archived.mp4"), testVideo),
             new PathAndContents(
                 archiveDirectory.resolve("Nested/recording3.archived.mp4"), testVideo),
             new PathAndContents(
@@ -817,8 +849,10 @@ class AppIntegrationTest {
     return path;
   }
 
-  private void runApp(Path inputDirectory, Path outputDirectory, Path archiveDirectory) {
-    App.main(inputDirectory.toString(), outputDirectory.toString(), archiveDirectory.toString());
+  private boolean runApp(Path inputDirectory, Path outputDirectory, Path archiveDirectory)
+      throws Exception {
+    App app = new App(new VideoEncoder(new HandBrake()), new VideoArchiver());
+    return app.run(inputDirectory, outputDirectory, archiveDirectory);
   }
 
   private IterableSubject.UsingCorrespondence<Path, PathAndContents> assertThatTestDirectory()

--- a/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/AppIntegrationTest.java
+++ b/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/AppIntegrationTest.java
@@ -849,7 +849,7 @@ class AppIntegrationTest {
 
   private boolean runApp(Path inputDirectory, Path outputDirectory, Path archiveDirectory)
       throws Exception {
-    App app = new App(new VideoEncoder(new HandBrake()), new VideoArchiver());
+    App app = new App(new VideoEncoder(HandBrake.newInstance()), new VideoArchiver());
     return app.run(inputDirectory, outputDirectory, archiveDirectory);
   }
 

--- a/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/AppIntegrationTest.java
+++ b/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/AppIntegrationTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.TestMethodOrder;
  *
  * <p>Requires HandBrakeCLI to be installed.
  *
+ * <p>May require re-encoding the .mp4 file in resources directory.
+ *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/AppIntegrationTest.java
+++ b/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/AppIntegrationTest.java
@@ -23,7 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 /**
- * Contains various scenarios testing {@link App} as a black box. Read the logs to understand each scenario further.
+ * Contains various scenarios testing {@link App} as a black box. Read the logs to understand each
+ * scenario further.
  *
  * <p>Requires HandBrakeCLI to be installed.
  *
@@ -648,8 +649,7 @@ class AppIntegrationTest {
 
   @Test
   @Order(61)
-  void singleVideo_encodingAlreadyExists_and_archiveExistsButContentsDiffer()
-      throws Exception {
+  void singleVideo_encodingAlreadyExists_and_archiveExistsButContentsDiffer() throws Exception {
     // Given
     // video to encode
     Path inputDirectory = createDirectoryAt(testDirectory.resolve("Gameplay"));
@@ -727,8 +727,7 @@ class AppIntegrationTest {
         .containsExactly(
             // originals
             new PathAndContents(inputDirectory.resolve("recording2.mp4"), testVideo),
-            new PathAndContents(
-                inputDirectory.resolve("Nested/recording3.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("Nested/recording3.mp4"), testVideo),
             // encodings
             new PathAndContents(inputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
             new PathAndContents(inputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),
@@ -809,8 +808,7 @@ class AppIntegrationTest {
         .containsExactly(
             // originals
             new PathAndContents(inputDirectory.resolve("recording2.mp4"), testVideo),
-            new PathAndContents(
-                inputDirectory.resolve("Nested/recording3.mp4"), testVideo),
+            new PathAndContents(inputDirectory.resolve("Nested/recording3.mp4"), testVideo),
             // encodings
             new PathAndContents(outputDirectory.resolve("recording1.cfr.mp4"), testVideoEncoded),
             new PathAndContents(outputDirectory.resolve("recording2.cfr.mp4"), testVideoEncoded),

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
@@ -1,10 +1,8 @@
 package com.willmolloy.handbrake.cfr;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Stopwatch;
-import com.willmolloy.handbrake.core.HandBrake;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -34,6 +32,14 @@ class App {
     this.videoArchiver = checkNotNull(videoArchiver);
   }
 
+  /**
+   * Runs the app.
+   *
+   * @param inputDirectory directory containing unencoded files
+   * @param outputDirectory directory to contain encoded files
+   * @param archiveDirectory directory to contain archived files
+   * @return {@code true} if all encoding and archiving was successful
+   */
   boolean run(Path inputDirectory, Path outputDirectory, Path archiveDirectory) throws Exception {
     Stopwatch stopwatch = Stopwatch.createStarted();
     log.info(
@@ -125,25 +131,5 @@ class App {
     }
 
     return overallSuccess;
-  }
-
-  public static void main(String... args) {
-    try {
-      checkArgument(args.length == 3, "Expected 3 args to main method");
-      Path inputDirectory = Path.of(args[0]);
-      Path outputDirectory = Path.of(args[1]);
-      Path archiveDirectory = Path.of(args[2]);
-
-      VideoEncoder videoEncoder = new VideoEncoder(new HandBrake());
-      VideoArchiver videoArchiver = new VideoArchiver();
-      App app = new App(videoEncoder, videoArchiver);
-
-      if (!app.run(inputDirectory, outputDirectory, archiveDirectory)) {
-        System.exit(1);
-      }
-    } catch (Throwable t) {
-      log.fatal("Fatal error", t);
-      System.exit(1);
-    }
   }
 }

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
@@ -100,7 +100,15 @@ class App {
         // if somebody wants to encode again, they'll need to remove the 'Archived' suffix
         .filter(path -> !UnencodedVideo.isEncodedMp4(path) && !UnencodedVideo.isArchivedMp4(path))
         .map(factory::newUnencodedVideo)
-        .sorted(Comparator.comparing(video -> video.originalPath().toString()))
+        .sorted(
+            Comparator.comparing(
+                video -> {
+                  try {
+                    return Files.getLastModifiedTime(video.originalPath());
+                  } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                }))
         .toList();
   }
 

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
@@ -100,15 +100,7 @@ class App {
         // if somebody wants to encode again, they'll need to remove the 'Archived' suffix
         .filter(path -> !UnencodedVideo.isEncodedMp4(path) && !UnencodedVideo.isArchivedMp4(path))
         .map(factory::newUnencodedVideo)
-        .sorted(
-            Comparator.comparing(
-                video -> {
-                  try {
-                    return Files.getLastModifiedTime(video.originalPath());
-                  } catch (IOException e) {
-                    throw new UncheckedIOException(e);
-                  }
-                }))
+        .sorted(Comparator.comparing(video -> video.originalPath().toString()))
         .toList();
   }
 

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
@@ -10,6 +10,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
@@ -93,6 +94,7 @@ class App {
         // if somebody wants to encode again, they'll need to remove the 'Archived' suffix
         .filter(path -> !UnencodedVideo.isEncodedMp4(path) && !UnencodedVideo.isArchivedMp4(path))
         .map(factory::newUnencodedVideo)
+        .sorted(Comparator.comparing(video -> video.originalPath().toString()))
         .toList();
   }
 

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/App.java
@@ -33,7 +33,7 @@ class App {
     this.videoArchiver = checkNotNull(videoArchiver);
   }
 
-  void run(Path inputDirectory, Path outputDirectory, Path archiveDirectory) throws Exception {
+  boolean run(Path inputDirectory, Path outputDirectory, Path archiveDirectory) throws Exception {
     Stopwatch stopwatch = Stopwatch.createStarted();
     log.info(
         "run(inputDirectory={}, outputDirectory={}, archiveDirectory={}) started",
@@ -48,10 +48,7 @@ class App {
           new UnencodedVideo.Factory(inputDirectory, outputDirectory, archiveDirectory);
       List<UnencodedVideo> unencodedVideos = getUnencodedVideos(inputDirectory, factory);
 
-      if (!encodeAndArchiveVideos(unencodedVideos)) {
-        // TODO aggregate exceptions/errors somehow. Need to change boolean returns.
-        throw new Error("Run failed. Read the logs.");
-      }
+      return encodeAndArchiveVideos(unencodedVideos);
     } finally {
       log.info("run finished - elapsed: {}", stopwatch.elapsed());
     }
@@ -139,7 +136,9 @@ class App {
       VideoArchiver videoArchiver = new VideoArchiver();
       App app = new App(videoEncoder, videoArchiver);
 
-      app.run(inputDirectory, outputDirectory, archiveDirectory);
+      if (!app.run(inputDirectory, outputDirectory, archiveDirectory)) {
+        System.exit(1);
+      }
     } catch (Throwable t) {
       log.fatal("Fatal error", t);
       System.exit(1);

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/Main.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/Main.java
@@ -24,9 +24,7 @@ final class Main {
       Path outputDirectory = Path.of(args[1]);
       Path archiveDirectory = Path.of(args[2]);
 
-      VideoEncoder videoEncoder = new VideoEncoder(new HandBrake());
-      VideoArchiver videoArchiver = new VideoArchiver();
-      App app = new App(videoEncoder, videoArchiver);
+      App app = new App(new VideoEncoder(new HandBrake()), new VideoArchiver());
 
       if (!app.run(inputDirectory, outputDirectory, archiveDirectory)) {
         System.exit(1);

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/Main.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/Main.java
@@ -1,0 +1,39 @@
+package com.willmolloy.handbrake.cfr;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.willmolloy.handbrake.core.HandBrake;
+import java.nio.file.Path;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Main entrypoint.
+ *
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+final class Main {
+  private Main() {}
+
+  private static final Logger log = LogManager.getLogger();
+
+  public static void main(String... args) {
+    try {
+      checkArgument(args.length == 3, "Expected 3 args to main method");
+      Path inputDirectory = Path.of(args[0]);
+      Path outputDirectory = Path.of(args[1]);
+      Path archiveDirectory = Path.of(args[2]);
+
+      VideoEncoder videoEncoder = new VideoEncoder(new HandBrake());
+      VideoArchiver videoArchiver = new VideoArchiver();
+      App app = new App(videoEncoder, videoArchiver);
+
+      if (!app.run(inputDirectory, outputDirectory, archiveDirectory)) {
+        System.exit(1);
+      }
+    } catch (Throwable t) {
+      log.fatal("Fatal error", t);
+      System.exit(1);
+    }
+  }
+}

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/Main.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/Main.java
@@ -24,7 +24,7 @@ final class Main {
       Path outputDirectory = Path.of(args[1]);
       Path archiveDirectory = Path.of(args[2]);
 
-      App app = new App(new VideoEncoder(new HandBrake()), new VideoArchiver());
+      App app = new App(new VideoEncoder(HandBrake.newInstance()), new VideoArchiver());
 
       if (!app.run(inputDirectory, outputDirectory, archiveDirectory)) {
         System.exit(1);

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
@@ -21,9 +21,10 @@ public class VideoArchiver {
    * Archives the given video.
    *
    * @param video video to archive
+   * @return {@code true} if archiving was successful
    */
-  public CompletableFuture<Void> archiveAsync(UnencodedVideo video) {
-    return CompletableFuture.runAsync(
+  public CompletableFuture<Boolean> archiveAsync(UnencodedVideo video) {
+    return CompletableFuture.supplyAsync(
         () -> {
           Stopwatch stopwatch = Stopwatch.createStarted();
           try {
@@ -39,7 +40,7 @@ public class VideoArchiver {
                     "Archive file ({}) already exists but contents differ, keeping original",
                     video.archivedPath());
               }
-              return;
+              return true;
             }
 
             Files.createDirectories(checkNotNull(video.archivedPath().getParent()));
@@ -50,8 +51,10 @@ public class VideoArchiver {
             Files.move(video.tempArchivedPath(), video.archivedPath());
 
             log.info("Archived: {} - elapsed: {}", video.archivedPath(), stopwatch.elapsed());
+            return true;
           } catch (Exception e) {
             log.error("Error archiving: %s".formatted(video), e);
+            return false;
           }
         });
   }

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
@@ -28,7 +28,7 @@ public class VideoArchiver {
         () -> {
           Stopwatch stopwatch = Stopwatch.createStarted();
           try {
-            log.info("Archiving: {} -> {}", video.originalPath(), video.archivedPath());
+            log.debug("Archiving: {} -> {}", video.originalPath(), video.archivedPath());
 
             if (Files.exists(video.archivedPath())) {
               if (Files.mismatch(video.originalPath(), video.archivedPath()) == -1) {

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
@@ -32,29 +32,35 @@ public class VideoArchiver {
 
             if (Files.exists(video.archivedPath())) {
               if (Files.mismatch(video.originalPath(), video.archivedPath()) == -1) {
-                log.warn(
-                    "Archive file ({}) already exists, deleting original", video.archivedPath());
-                Files.delete(video.originalPath());
+                log.warn("Archive file ({}) already exists", video.archivedPath());
+                if (!video.originalPath().equals(video.archivedPath())) {
+                  log.info("Deleting: {}", video.originalPath());
+                  Files.delete(video.originalPath());
+                }
+                return true;
               } else {
-                log.warn(
-                    "Archive file ({}) already exists but contents differ, keeping original",
+                log.error(
+                    "Archive file ({}) already exists but contents differ. Aborting",
                     video.archivedPath());
+                return false;
               }
-              return true;
             }
 
             Files.createDirectories(checkNotNull(video.archivedPath().getParent()));
 
+            log.info("Moving: {} -> {}", video.originalPath(), video.archivedPath());
             // archive to a temp file first in case something goes wrong
             // (e.g. app crash while it's uploading to NAS)
             Files.move(video.originalPath(), video.tempArchivedPath());
             Files.move(video.tempArchivedPath(), video.archivedPath());
 
-            log.info("Archived: {} - elapsed: {}", video.archivedPath(), stopwatch.elapsed());
+            log.info("Archived: {}", video.archivedPath());
             return true;
           } catch (Exception e) {
             log.error("Error archiving: %s".formatted(video), e);
             return false;
+          } finally {
+            log.info("Elapsed: {}", stopwatch.elapsed());
           }
         });
   }

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
@@ -13,7 +13,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public class VideoArchiver {
+class VideoArchiver {
 
   private static final Logger log = LogManager.getLogger();
 

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
@@ -18,13 +18,13 @@ import org.apache.logging.log4j.Logger;
  *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public class VideoEncoder {
+class VideoEncoder {
 
   private static final Logger log = LogManager.getLogger();
 
   private final HandBrake handBrake;
 
-  public VideoEncoder(HandBrake handBrake) {
+  VideoEncoder(HandBrake handBrake) {
     this.handBrake = checkNotNull(handBrake);
   }
 

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
@@ -37,7 +37,7 @@ public class VideoEncoder {
   public boolean encode(UnencodedVideo video) {
     Stopwatch stopwatch = Stopwatch.createStarted();
     try {
-      log.info("Encoding: {} -> {}", video.originalPath(), video.encodedPath());
+      log.debug("Encoding: {} -> {}", video.originalPath(), video.encodedPath());
 
       if (Files.exists(video.encodedPath())) {
         log.error("Encoded file ({}) already exists. Aborting", video.encodedPath());

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
@@ -40,15 +40,15 @@ public class VideoEncoder {
       log.info("Encoding: {} -> {}", video.originalPath(), video.encodedPath());
 
       if (Files.exists(video.encodedPath())) {
-        log.warn("Encoded file ({}) already exists", video.encodedPath());
-        return true;
+        log.error("Encoded file ({}) already exists. Aborting", video.encodedPath());
+        return false;
       }
 
       Files.createDirectories(checkNotNull(video.encodedPath().getParent()));
 
       // to avoid leaving encoded files in an 'incomplete' state, encode to a temp file in case
       // something goes wrong
-      boolean encodeSuccessful =
+      boolean handBrakeSuccessful =
           handBrake.encode(
               Input.of(video.originalPath()),
               Output.of(video.tempEncodedPath()),
@@ -56,9 +56,9 @@ public class VideoEncoder {
               Encoder.h264(),
               FrameRateControl.constant());
 
-      if (encodeSuccessful) {
+      if (handBrakeSuccessful) {
         Files.move(video.tempEncodedPath(), video.encodedPath());
-        log.info("Encoded: {} - elapsed: {}", video.encodedPath(), stopwatch.elapsed());
+        log.info("Encoded: {}", video.encodedPath());
         return true;
       } else {
         log.error("Error encoding: {}", video);
@@ -67,6 +67,8 @@ public class VideoEncoder {
     } catch (Exception e) {
       log.error("Error encoding: %s".formatted(video), e);
       return false;
+    } finally {
+      log.info("Elapsed: {}", stopwatch.elapsed());
     }
   }
 }

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/adhoc/FileRenamer.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/adhoc/FileRenamer.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public class FileRenamer {
+class FileRenamer {
 
   private static final Logger log = LogManager.getLogger();
 

--- a/auto-handbrake-cfr/src/main/resources/log4j2.xml
+++ b/auto-handbrake-cfr/src/main/resources/log4j2.xml
@@ -10,15 +10,15 @@
             <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%c{1.}] - %msg%n"/>
         </Console>
 
-        <File name="file" fileName="logs/${fileNameDate}.log">
-            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] [%c] [%M] - %msg%n"/>
-        </File>
+<!--        <File name="file" fileName="logs/${fileNameDate}.log">-->
+<!--            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] [%c] [%M] - %msg%n"/>-->
+<!--        </File>-->
     </Appenders>
 
     <Loggers>
         <Root level="info">
             <AppenderRef ref="console"/>
-            <AppenderRef ref="file"/>
+<!--            <AppenderRef ref="file"/>-->
         </Root>
 
         <Logger name="com.willmolloy" level="debug"/>

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/Cli.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/Cli.java
@@ -2,7 +2,6 @@ package com.willmolloy.handbrake.core;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -26,13 +25,8 @@ class Cli {
 
   private final Supplier<ProcessBuilder> processBuilderSupplier;
 
-  @VisibleForTesting
   Cli(Supplier<ProcessBuilder> processBuilderSupplier) {
     this.processBuilderSupplier = checkNotNull(processBuilderSupplier);
-  }
-
-  Cli() {
-    this(ProcessBuilder::new);
   }
 
   /**

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/Cli.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/Cli.java
@@ -2,6 +2,7 @@ package com.willmolloy.handbrake.core;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -25,6 +26,7 @@ class Cli {
 
   private final Supplier<ProcessBuilder> processBuilderSupplier;
 
+  @VisibleForTesting
   Cli(Supplier<ProcessBuilder> processBuilderSupplier) {
     this.processBuilderSupplier = checkNotNull(processBuilderSupplier);
   }

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrake.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrake.java
@@ -1,41 +1,15 @@
 package com.willmolloy.handbrake.core;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.annotations.VisibleForTesting;
 import com.willmolloy.handbrake.core.options.Input;
 import com.willmolloy.handbrake.core.options.Option;
 import com.willmolloy.handbrake.core.options.Output;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-import java.util.stream.Stream;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * HandBrake interface.
  *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public class HandBrake {
-
-  private static final Logger log = LogManager.getLogger();
-
-  private static final Lock LOCK = new ReentrantLock();
-
-  private final Cli cli;
-
-  @VisibleForTesting
-  HandBrake(Cli cli) {
-    this.cli = checkNotNull(cli);
-  }
-
-  public HandBrake() {
-    this(new Cli());
-  }
+public interface HandBrake {
 
   /**
    * Runs HandBrake encoding.
@@ -45,42 +19,9 @@ public class HandBrake {
    * @param options HandBrake options
    * @return {@code true} if encoding was successful
    */
-  public boolean encode(Input input, Output output, Option... options) {
-    if (Files.exists(output.value())) {
-      log.warn("Output ({}) already exists", output.value());
-    }
+  boolean encode(Input input, Output output, Option... options);
 
-    List<String> command =
-        Stream.concat(
-                Stream.of(
-                    "HandBrakeCLI",
-                    input.key(),
-                    input.value().toString(),
-                    output.key(),
-                    output.value().toString()),
-                Arrays.stream(options)
-                    .flatMap(
-                        option -> {
-                          // TODO exhaustive switch for sealed type
-                          // TODO record deconstructor - can't since we have interfaces??
-                          if (option instanceof Option.KeyOnlyOption o) {
-                            return Stream.of(o.key());
-                          }
-                          if (option instanceof Option.KeyValueOption<?> o) {
-                            return Stream.of(o.key(), o.value().toString());
-                          }
-                          return Stream.of();
-                        }))
-            .toList();
-
-    LOCK.lock();
-    try {
-      return cli.execute(command, new HandBrakeLogger(log));
-    } catch (Exception e) {
-      log.error("Error encoding: %s".formatted(input), e);
-      return false;
-    } finally {
-      LOCK.unlock();
-    }
+  static HandBrake newInstance() {
+    return new HandBrakeImpl(new Cli(ProcessBuilder::new));
   }
 }

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrake.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrake.java
@@ -2,6 +2,7 @@ package com.willmolloy.handbrake.core;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.willmolloy.handbrake.core.options.Input;
 import com.willmolloy.handbrake.core.options.Option;
 import com.willmolloy.handbrake.core.options.Output;
@@ -27,6 +28,7 @@ public class HandBrake {
 
   private final Cli cli;
 
+  @VisibleForTesting
   HandBrake(Cli cli) {
     this.cli = checkNotNull(cli);
   }

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrake.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrake.java
@@ -45,8 +45,8 @@ public class HandBrake {
    */
   public boolean encode(Input input, Output output, Option... options) {
     if (Files.exists(output.value())) {
-      log.warn("Output ({}) already exists", output.value());
-      return true;
+      log.error("Output ({}) already exists. Aborting", output.value());
+      return false;
     }
 
     List<String> command =

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrake.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrake.java
@@ -45,8 +45,7 @@ public class HandBrake {
    */
   public boolean encode(Input input, Output output, Option... options) {
     if (Files.exists(output.value())) {
-      log.error("Output ({}) already exists. Aborting", output.value());
-      return false;
+      log.warn("Output ({}) already exists", output.value());
     }
 
     List<String> command =

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrakeImpl.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrakeImpl.java
@@ -1,0 +1,81 @@
+package com.willmolloy.handbrake.core;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.willmolloy.handbrake.core.options.Input;
+import com.willmolloy.handbrake.core.options.Option;
+import com.willmolloy.handbrake.core.options.Output;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * HandBrake implementation.
+ *
+ * @see HandBrake#newInstance
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+class HandBrakeImpl implements HandBrake {
+
+  private static final Logger log = LogManager.getLogger();
+
+  private static final Lock LOCK = new ReentrantLock();
+
+  private final Cli cli;
+
+  HandBrakeImpl(Cli cli) {
+    this.cli = checkNotNull(cli);
+  }
+
+  /**
+   * Runs HandBrake encoding.
+   *
+   * @param input input file
+   * @param output output file
+   * @param options HandBrake options
+   * @return {@code true} if encoding was successful
+   */
+  public boolean encode(Input input, Output output, Option... options) {
+    if (Files.exists(output.value())) {
+      log.warn("Output ({}) already exists", output.value());
+    }
+
+    List<String> command =
+        Stream.concat(
+                Stream.of(
+                    "HandBrakeCLI",
+                    input.key(),
+                    input.value().toString(),
+                    output.key(),
+                    output.value().toString()),
+                Arrays.stream(options)
+                    .flatMap(
+                        option -> {
+                          // TODO exhaustive switch for sealed type
+                          // TODO record deconstructor - can't since we have interfaces??
+                          if (option instanceof Option.KeyOnlyOption o) {
+                            return Stream.of(o.key());
+                          }
+                          if (option instanceof Option.KeyValueOption<?> o) {
+                            return Stream.of(o.key(), o.value().toString());
+                          }
+                          return Stream.of();
+                        }))
+            .toList();
+
+    LOCK.lock();
+    try {
+      return cli.execute(command, new HandBrakeLogger(log));
+    } catch (Exception e) {
+      log.error("Error encoding: %s".formatted(input), e);
+      return false;
+    } finally {
+      LOCK.unlock();
+    }
+  }
+}

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrakeImpl.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrakeImpl.java
@@ -32,14 +32,6 @@ class HandBrakeImpl implements HandBrake {
     this.cli = checkNotNull(cli);
   }
 
-  /**
-   * Runs HandBrake encoding.
-   *
-   * @param input input file
-   * @param output output file
-   * @param options HandBrake options
-   * @return {@code true} if encoding was successful
-   */
   public boolean encode(Input input, Output output, Option... options) {
     if (Files.exists(output.value())) {
       log.warn("Output ({}) already exists", output.value());

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrakeImpl.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrakeImpl.java
@@ -62,7 +62,7 @@ class HandBrakeImpl implements HandBrake {
 
     LOCK.lock();
     try {
-      return cli.execute(command, new HandBrakeLogger(log));
+      return cli.execute(command, new HandBrakeLogger());
     } catch (Exception e) {
       log.error("Error encoding: %s".formatted(input), e);
       return false;

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrakeLogger.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/HandBrakeLogger.java
@@ -2,12 +2,14 @@ package com.willmolloy.handbrake.core;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashSet;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
@@ -35,8 +37,13 @@ class HandBrakeLogger implements Consumer<String> {
 
   private final Logger log;
 
+  @VisibleForTesting
   HandBrakeLogger(Logger log) {
     this.log = checkNotNull(log);
+  }
+
+  HandBrakeLogger() {
+    this(LogManager.getLogger());
   }
 
   @Override

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/Job.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/Job.java
@@ -1,2 +1,0 @@
-package com.willmolloy.handbrake.core;public interface Job {
-}

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/Job.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/Job.java
@@ -1,0 +1,2 @@
+package com.willmolloy.handbrake.core;public interface Job {
+}

--- a/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/HandBrakeImplTest.java
+++ b/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/HandBrakeImplTest.java
@@ -29,11 +29,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
 @ExtendWith(MockitoExtension.class)
-class HandBrakeTest {
+class HandBrakeImplTest {
 
   @Mock private Cli mockCli;
 
-  @InjectMocks private HandBrake handBrake;
+  @InjectMocks private HandBrakeImpl handBrake;
 
   @Test
   void successfulEncodingReturnsTrue() {

--- a/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/HandBrakeTest.java
+++ b/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/HandBrakeTest.java
@@ -69,13 +69,13 @@ class HandBrakeTest {
   }
 
   @Test
-  void outputAlreadyExistsReturnsEarly() throws IOException {
+  void outputAlreadyExistsReturnsFalse() throws IOException {
     Path input = Path.of("input.mp4");
     Path output = Path.of("output.mp4");
 
     try {
       Files.createFile(output);
-      assertThat(handBrake.encode(Input.of(input), Output.of(output))).isTrue();
+      assertThat(handBrake.encode(Input.of(input), Output.of(output))).isFalse();
       verify(mockCli, never()).execute(anyList(), any());
     } finally {
       Files.delete(output);

--- a/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/HandBrakeTest.java
+++ b/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/HandBrakeTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -69,14 +68,19 @@ class HandBrakeTest {
   }
 
   @Test
-  void outputAlreadyExistsReturnsFalse() throws IOException {
+  void outputAlreadyExistsOverwrites() throws IOException {
     Path input = Path.of("input.mp4");
     Path output = Path.of("output.mp4");
 
+    when(mockCli.execute(anyList(), any())).thenReturn(true);
+
     try {
       Files.createFile(output);
-      assertThat(handBrake.encode(Input.of(input), Output.of(output))).isFalse();
-      verify(mockCli, never()).execute(anyList(), any());
+      assertThat(handBrake.encode(Input.of(input), Output.of(output))).isTrue();
+      verify(mockCli)
+          .execute(
+              eq(List.of("HandBrakeCLI", "--input", "input.mp4", "--output", "output.mp4")),
+              isA(HandBrakeLogger.class));
     } finally {
       Files.delete(output);
     }


### PR DESCRIPTION
Main change - if encoded or archive file already exists, then aborts so
files aren't overwritten. Returns exit code 1 if anything failed.