### PR TITLE
Refactor options to use polymorphism rather than switch/case style

### DIFF
--- a/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/VideoEncoderTest.java
+++ b/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/VideoEncoderTest.java
@@ -76,8 +76,8 @@ class VideoEncoderTest {
                 invocation -> {
                   // bit of an ugly hack...
                   // need to create the temp encoded file as its expected as output from HandBrake
-                  Output handBrakeOutput = invocation.getArgument(1);
-                  Files.createFile(handBrakeOutput.value());
+                  Output output = invocation.getArgument(1);
+                  Files.createFile(output.path());
                   return true;
                 });
 
@@ -111,8 +111,8 @@ class VideoEncoderTest {
                 invocation -> {
                   // bit of an ugly hack...
                   // need to create the temp encoded file as its expected as output from HandBrake
-                  Output handBrakeOutput = invocation.getArgument(1);
-                  Files.createFile(handBrakeOutput.value());
+                  Output output = invocation.getArgument(1);
+                  Files.createFile(output.path());
                   return true;
                 });
 

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Encoder.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Encoder.java
@@ -7,8 +7,7 @@ package com.willmolloy.handbrake.core.options;
  *     Options</a>
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public sealed interface Encoder extends Option.KeyValueOption<String>
-    permits Internals.KeyStringValueOptionImpl {
+public sealed interface Encoder extends Option permits Internals.OptionImpl {
 
   /** H.264 (CPU). */
   static Encoder h264() {
@@ -43,6 +42,6 @@ public sealed interface Encoder extends Option.KeyValueOption<String>
   }
 
   private static Encoder encoder(String value) {
-    return new Internals.KeyStringValueOptionImpl("--encoder", value);
+    return new Internals.OptionImpl("--encoder", value);
   }
 }

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/FrameRateControl.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/FrameRateControl.java
@@ -7,7 +7,7 @@ package com.willmolloy.handbrake.core.options;
  *     Options</a>
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public sealed interface FrameRateControl extends Option.KeyOnlyOption permits Internals.OptionImpl {
+public sealed interface FrameRateControl extends Option permits Internals.OptionImpl {
 
   /** Constant frame rate. */
   static FrameRateControl constant() {

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Input.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Input.java
@@ -9,10 +9,11 @@ import java.nio.file.Path;
  *     Options</a>
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public sealed interface Input extends Option.KeyValueOption<Path>
-    permits Internals.KeyPathValueOptionImpl {
+public sealed interface Input extends Option permits Internals.InputOutputOptionImpl {
+
+  Path path();
 
   static Input of(Path path) {
-    return new Internals.KeyPathValueOptionImpl("--input", path);
+    return new Internals.InputOutputOptionImpl("--input", path);
   }
 }

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Option.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Option.java
@@ -1,5 +1,7 @@
 package com.willmolloy.handbrake.core.options;
 
+import java.util.stream.Stream;
+
 /**
  * HandBrake options.
  *
@@ -7,20 +9,7 @@ package com.willmolloy.handbrake.core.options;
  *     reference</a>
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public sealed interface Option permits Option.KeyOnlyOption, Option.KeyValueOption {
+public sealed interface Option permits Input, Output, Preset, Encoder, FrameRateControl {
 
-  String key();
-
-  /** Option with key only. */
-  // marker interface allows us to exhaustively switch Option interface
-  sealed interface KeyOnlyOption extends Option permits FrameRateControl {}
-
-  /**
-   * Option with key and value.
-   *
-   * @param <T> value type
-   */
-  sealed interface KeyValueOption<T> extends Option permits Input, Output, Preset, Encoder {
-    T value();
-  }
+  Stream<String> handBrakeCliArgs();
 }

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Output.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Output.java
@@ -9,10 +9,11 @@ import java.nio.file.Path;
  *     Options</a>
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public sealed interface Output extends Option.KeyValueOption<Path>
-    permits Internals.KeyPathValueOptionImpl {
+public sealed interface Output extends Option permits Internals.InputOutputOptionImpl {
+
+  Path path();
 
   static Output of(Path path) {
-    return new Internals.KeyPathValueOptionImpl("--output", path);
+    return new Internals.InputOutputOptionImpl("--output", path);
   }
 }

--- a/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Preset.java
+++ b/auto-handbrake-core/src/main/java/com/willmolloy/handbrake/core/options/Preset.java
@@ -7,8 +7,7 @@ package com.willmolloy.handbrake.core.options;
  *     presets</a>
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public sealed interface Preset extends Option.KeyValueOption<String>
-    permits Internals.KeyStringValueOptionImpl {
+public sealed interface Preset extends Option permits Internals.OptionImpl {
 
   /** Production Max preset. */
   static Preset productionMax() {
@@ -25,6 +24,6 @@ public sealed interface Preset extends Option.KeyValueOption<String>
   }
 
   private static Preset preset(String value) {
-    return new Internals.KeyStringValueOptionImpl("--preset", value);
+    return new Internals.OptionImpl("--preset", value);
   }
 }

--- a/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/EncoderTest.java
+++ b/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/EncoderTest.java
@@ -1,6 +1,6 @@
 package com.willmolloy.handbrake.core.options;
 
-import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,12 +16,12 @@ class EncoderTest {
 
   @ParameterizedTest
   @MethodSource
-  void testFactoriesExpectedKeysAndValues(Encoder encoder, String key, String value) {
-    assertThat(encoder.key()).isEqualTo(key);
-    assertThat(encoder.value()).isEqualTo(value);
+  void testFactoriesExpectedHandBrakeCliArgs(
+      Encoder encoder, String expectedKey, String expectedValue) {
+    assertThat(encoder.handBrakeCliArgs()).containsExactly(expectedKey, expectedValue).inOrder();
   }
 
-  static Stream<Arguments> testFactoriesExpectedKeysAndValues() {
+  static Stream<Arguments> testFactoriesExpectedHandBrakeCliArgs() {
     return Stream.of(
         Arguments.of(Encoder.h264(), "--encoder", "x264"),
         Arguments.of(Encoder.h265(), "--encoder", "x265"),

--- a/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/FrameRateControlTest.java
+++ b/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/FrameRateControlTest.java
@@ -1,6 +1,6 @@
 package com.willmolloy.handbrake.core.options;
 
-import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,11 +16,12 @@ class FrameRateControlTest {
 
   @ParameterizedTest
   @MethodSource
-  void testFactoriesExpectedKeys(FrameRateControl frameRateControl, String value) {
-    assertThat(frameRateControl.key()).isEqualTo(value);
+  void testFactoriesExpectedHandBrakeCliArgs(
+      FrameRateControl frameRateControl, String expectedKey) {
+    assertThat(frameRateControl.handBrakeCliArgs()).containsExactly(expectedKey).inOrder();
   }
 
-  static Stream<Arguments> testFactoriesExpectedKeys() {
+  static Stream<Arguments> testFactoriesExpectedHandBrakeCliArgs() {
     return Stream.of(
         Arguments.of(FrameRateControl.constant(), "--cfr"),
         Arguments.of(FrameRateControl.variable(), "--vfr"),

--- a/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/InputTest.java
+++ b/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/InputTest.java
@@ -1,6 +1,5 @@
 package com.willmolloy.handbrake.core.options;
 
-import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 
 import java.nio.file.Path;
@@ -14,12 +13,12 @@ import org.junit.jupiter.api.Test;
 class InputTest {
 
   @Test
-  void testFactoryForwardsPathAndExpectedKey() {
+  void testFactoryForwardsPathAndExpectedHandBrakeCliArgs() {
     Path path = Path.of("123");
 
     Input input = Input.of(path);
 
-    assertThat(input.key()).isEqualTo("--input");
-    assertThat(input.value()).isSameInstanceAs(path);
+    assertThat(input.path()).isSameInstanceAs(path);
+    assertThat(input.handBrakeCliArgs()).containsExactly("--input", path.toString()).inOrder();
   }
 }

--- a/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/OutputTest.java
+++ b/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/OutputTest.java
@@ -14,12 +14,12 @@ import org.junit.jupiter.api.Test;
 class OutputTest {
 
   @Test
-  void testFactoryForwardsPathAndExpectedKey() {
+  void testFactoryForwardsPathAndExpectedHandBrakeCliArgs() {
     Path path = Path.of("123");
 
     Output output = Output.of(path);
 
-    assertThat(output.key()).isEqualTo("--output");
-    assertThat(output.value()).isSameInstanceAs(path);
+    assertThat(output.path()).isSameInstanceAs(path);
+    assertThat(output.handBrakeCliArgs()).containsExactly("--output", path.toString()).inOrder();
   }
 }

--- a/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/PresetTest.java
+++ b/auto-handbrake-core/src/test/java/com/willmolloy/handbrake/core/options/PresetTest.java
@@ -1,6 +1,6 @@
 package com.willmolloy.handbrake.core.options;
 
-import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,12 +16,12 @@ class PresetTest {
 
   @ParameterizedTest
   @MethodSource
-  void testFactoriesExpectedKeysAndValues(Preset preset, String key, String value) {
-    assertThat(preset.key()).isEqualTo(key);
-    assertThat(preset.value()).isEqualTo(value);
+  void testFactoriesExpectedHandBrakeCliArgs(
+      Preset preset, String expectedKey, String expectedValue) {
+    assertThat(preset.handBrakeCliArgs()).containsExactly(expectedKey, expectedValue).inOrder();
   }
 
-  static Stream<Arguments> testFactoriesExpectedKeysAndValues() {
+  static Stream<Arguments> testFactoriesExpectedHandBrakeCliArgs() {
     return Stream.of(
         Arguments.of(Preset.productionMax(), "--preset", "Production Max"),
         Arguments.of(Preset.productionStandard(), "--preset", "Production Standard"));


### PR DESCRIPTION
Also hides the implementation details that weren't used (still expose path for input/output - could simply pass path to the handbrake method, but IMO the custom interfaces are nicer because it's more consistent).