### PR TITLE
Overwrite encoded file if contents match

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Automating HandBrake encoding
       - It works with any framerate
       - It creates quite a large file afterwards, but it's ideal "as an intermediate format for video editing"
       - I recommend deleting the encoded file after using it, and retaining the original archived file
-    - Encoded files are not overwritten, if you want to encode again, delete them first
 3. Archives original videos
 
 #### Usage:

--- a/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/IncompleteFilesExistTest.java
+++ b/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/IncompleteFilesExistTest.java
@@ -35,7 +35,7 @@ class IncompleteFilesExistTest extends BaseIntegrationTest {
     createVideoAt(archiveDirectory.resolve("vid3.mp4.part"), unencodedVideo1);
 
     // When
-    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = app.run(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
     assertThat(result).isTrue();

--- a/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/SeveralVideosNestedDirectoryStructureTest.java
+++ b/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/SeveralVideosNestedDirectoryStructureTest.java
@@ -28,7 +28,7 @@ class SeveralVideosNestedDirectoryStructureTest extends BaseIntegrationTest {
     createVideoAt(inputDirectory.resolve("Nested1/Nested2/recording4.mp4"), unencodedVideo2);
 
     // When
-    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = app.run(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
     assertThat(result).isTrue();

--- a/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/SingleVideoNestedDirectoryStructureTest.java
+++ b/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/SingleVideoNestedDirectoryStructureTest.java
@@ -25,7 +25,7 @@ class SingleVideoNestedDirectoryStructureTest extends BaseIntegrationTest {
     createVideoAt(inputDirectory.resolve("League of Legends/ranked_game1.mp4"), unencodedVideo1);
 
     // When
-    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = app.run(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
     assertThat(result).isTrue();

--- a/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/SingleVideoTest.java
+++ b/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/SingleVideoTest.java
@@ -25,7 +25,7 @@ class SingleVideoTest extends BaseIntegrationTest {
     createVideoAt(inputDirectory.resolve("my video.mp4"), unencodedVideo1);
 
     // When
-    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = app.run(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
     assertThat(result).isTrue();

--- a/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/UnrelatedFilesExistTest.java
+++ b/auto-handbrake-cfr/src/integrationTest/java/com/willmolloy/handbrake/cfr/UnrelatedFilesExistTest.java
@@ -30,7 +30,7 @@ class UnrelatedFilesExistTest extends BaseIntegrationTest {
     createVideoAt(archiveDirectory.resolve("document.txt"), encodedVideo2);
 
     // When
-    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = app.run(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
     assertThat(result).isTrue();
@@ -68,11 +68,10 @@ class UnrelatedFilesExistTest extends BaseIntegrationTest {
     createVideoAt(archiveDirectory.resolve("recording3.mp4"), unencodedVideo1);
 
     // When
-    boolean result = runApp(inputDirectory, outputDirectory, archiveDirectory);
+    boolean result = app.run(inputDirectory, outputDirectory, archiveDirectory);
 
     // Then
-    // fails when input=archive since it would've tried to encode the archived files
-    assertThat(result).isEqualTo(!inputDirectory.equals(archiveDirectory));
+    assertThat(result).isTrue();
     assertThatTestDirectory()
         .containsExactly(
             // encoding

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
@@ -63,7 +63,7 @@ class VideoArchiver {
       Files.move(video.originalPath(), video.tempArchivedPath());
       Files.move(video.tempArchivedPath(), video.archivedPath());
 
-      log.info("Successfully archived: {}", video.archivedPath());
+      log.info("Archived: {}", video.archivedPath());
       return true;
     } catch (Exception e) {
       log.error("Error archiving: %s".formatted(video), e);

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
@@ -44,7 +44,7 @@ class VideoArchiver {
       if (Files.exists(video.archivedPath())) {
         if (Files.mismatch(video.originalPath(), video.archivedPath()) != -1) {
           log.error(
-              "Archive file ({}) already exists but contents differ. Aborting archive process",
+              "Archive file ({}) already exists but contents differ. Skipping archive process",
               video.archivedPath());
           return false;
         } else {

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoArchiver.java
@@ -44,7 +44,7 @@ class VideoArchiver {
       if (Files.exists(video.archivedPath())) {
         if (Files.mismatch(video.originalPath(), video.archivedPath()) != -1) {
           log.error(
-              "Archive file ({}) already exists but contents differ. Skipping archive process",
+              "Archive file ({}) already exists but contents differ. Aborting archive process",
               video.archivedPath());
           return false;
         } else {
@@ -63,7 +63,7 @@ class VideoArchiver {
       Files.move(video.originalPath(), video.tempArchivedPath());
       Files.move(video.tempArchivedPath(), video.archivedPath());
 
-      log.info("Archived: {}", video.archivedPath());
+      log.info("Successfully archived: {}", video.archivedPath());
       return true;
     } catch (Exception e) {
       log.error("Error archiving: %s".formatted(video), e);

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
@@ -3,6 +3,7 @@ package com.willmolloy.handbrake.cfr;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.willmolloy.handbrake.cfr.util.Async;
+import com.willmolloy.handbrake.cfr.util.Files2;
 import com.willmolloy.handbrake.cfr.util.Timer;
 import com.willmolloy.handbrake.core.HandBrake;
 import com.willmolloy.handbrake.core.options.Encoder;
@@ -67,7 +68,7 @@ class VideoEncoder {
 
       if (handBrakeSuccessful) {
         if (Files.exists(video.encodedPath())
-            && Files.mismatch(video.encodedPath(), video.tempEncodedPath()) != -1) {
+            && !Files2.contentsSimilar(video.encodedPath(), video.tempEncodedPath())) {
           log.error("Existing encoded file contents differ. Aborting encode process");
           return false;
         }

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/VideoEncoder.java
@@ -50,7 +50,6 @@ class VideoEncoder {
       log.debug("Encoding: {} -> {}", video.originalPath(), video.encodedPath());
 
       if (Files.exists(video.encodedPath())) {
-        // if the encoded file already exists, re-encode anyway. Will compare contents afterwards.
         log.warn("Encoded file ({}) already exists", video.encodedPath());
       }
 
@@ -74,7 +73,7 @@ class VideoEncoder {
         }
         Files.move(
             video.tempEncodedPath(), video.encodedPath(), StandardCopyOption.REPLACE_EXISTING);
-        log.info("Successfully encoded: {}", video.encodedPath());
+        log.info("Encoded: {}", video.encodedPath());
         return true;
       } else {
         log.error("Error encoding: {}", video);

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/util/Files2.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/util/Files2.java
@@ -1,0 +1,53 @@
+package com.willmolloy.handbrake.cfr.util;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+/**
+ * File utility methods. (Extension to {@link Files}.)
+ *
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+public final class Files2 {
+
+  /**
+   * Tests if two files have similar contents.
+   *
+   * <p>Specifically if <1% of bytes mismatch.
+   *
+   * @param path1 first file
+   * @param path2 second file
+   * @return {@code true} if the files contents are similar
+   * @see Files#mismatch
+   */
+  // HandBrake is not deterministic (encoding doesn't always produce the exact same output) so need
+  // a method to test file contents are similar when comparing encoded files.
+  public static boolean contentsSimilar(Path path1, Path path2) {
+    return percentMismatch(path1, path2) < 0.01;
+  }
+
+  private static double percentMismatch(Path path1, Path path2) {
+    try {
+      byte[] bytes1 = Files.readAllBytes(path1);
+      byte[] bytes2 = Files.readAllBytes(path2);
+      // pad arrays to same length
+      byte[] paddedBytes1 = Arrays.copyOf(bytes1, Math.max(bytes1.length, bytes2.length));
+      byte[] paddedBytes2 = Arrays.copyOf(bytes2, Math.max(bytes1.length, bytes2.length));
+
+      long mismatchCount =
+          IntStream.range(0, paddedBytes1.length)
+              .filter(i -> paddedBytes1[i] != paddedBytes2[i])
+              .count();
+
+      return (double) mismatchCount / paddedBytes1.length;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private Files2() {}
+}

--- a/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/VideoArchiverTest.java
+++ b/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/VideoArchiverTest.java
@@ -117,16 +117,6 @@ class VideoArchiverTest {
   }
 
   @Test
-  void exceptionCaughtReturnsFalse() {
-    // When
-    // null input forces NPE
-    boolean result = videoArchiver.archiveAsync(null).join();
-
-    // Then
-    assertThat(result).isFalse();
-  }
-
-  @Test
   void whenInputDirectoryIsArchiveDirectory_retainsOriginal_andReturnsTrue() throws IOException {
     // Given
     Path unencodedMp4File = Files.copy(testVideo, inputDirectory.resolve("file.mp4"));
@@ -140,6 +130,16 @@ class VideoArchiverTest {
     // Then
     assertThat(result).isTrue();
     assertThatTestDirectory().containsExactly(inputDirectory.resolve("file.mp4"));
+  }
+
+  @Test
+  void exceptionCaughtReturnsFalse() {
+    // When
+    // null input forces NPE
+    boolean result = videoArchiver.archiveAsync(null).join();
+
+    // Then
+    assertThat(result).isFalse();
   }
 
   private StreamSubject assertThatTestDirectory() throws IOException {

--- a/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/VideoEncoderTest.java
+++ b/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/VideoEncoderTest.java
@@ -82,13 +82,7 @@ class VideoEncoderTest {
 
     // Then
     assertThat(result).isTrue();
-    verify(mockHandBrake)
-        .encode(
-            Input.of(unencodedVideo.originalPath()),
-            Output.of(unencodedVideo.tempEncodedPath()),
-            Preset.productionStandard(),
-            Encoder.h264(),
-            FrameRateControl.constant());
+    verifyHandBrakeCalled(unencodedVideo);
     assertThatTestDirectory()
         .containsExactly(unencodedVideo.originalPath(), unencodedVideo.encodedPath());
   }
@@ -109,13 +103,7 @@ class VideoEncoderTest {
 
     // Then
     assertThat(result).isTrue();
-    verify(mockHandBrake)
-        .encode(
-            Input.of(unencodedVideo.originalPath()),
-            Output.of(outputDirectory.resolve("Halo/Campaign/file.cfr.mp4.part")),
-            Preset.productionStandard(),
-            Encoder.h264(),
-            FrameRateControl.constant());
+    verifyHandBrakeCalled(unencodedVideo);
     assertThatTestDirectory()
         .containsExactly(unencodedVideo.originalPath(), unencodedVideo.encodedPath());
   }
@@ -134,6 +122,7 @@ class VideoEncoderTest {
 
     // Then
     assertThat(result).isFalse();
+    verifyHandBrakeCalled(unencodedVideo);
     assertThatTestDirectory()
         .containsExactly(unencodedVideo.originalPath(), unencodedVideo.tempEncodedPath());
   }
@@ -152,6 +141,7 @@ class VideoEncoderTest {
 
     // Then
     assertThat(result).isFalse();
+    verifyHandBrakeCalled(unencodedVideo);
     assertThatTestDirectory().containsExactly(unencodedVideo.originalPath());
   }
 
@@ -171,13 +161,7 @@ class VideoEncoderTest {
 
     // Then
     assertThat(result).isTrue();
-    verify(mockHandBrake)
-        .encode(
-            Input.of(unencodedVideo.originalPath()),
-            Output.of(unencodedVideo.tempEncodedPath()),
-            Preset.productionStandard(),
-            Encoder.h264(),
-            FrameRateControl.constant());
+    verifyHandBrakeCalled(unencodedVideo);
     assertThatTestDirectory()
         .containsExactly(unencodedVideo.originalPath(), unencodedVideo.encodedPath());
   }
@@ -199,22 +183,12 @@ class VideoEncoderTest {
 
     // Then
     assertThat(result).isFalse();
-    verify(mockHandBrake)
-        .encode(
-            Input.of(unencodedVideo.originalPath()),
-            Output.of(unencodedVideo.tempEncodedPath()),
-            Preset.productionStandard(),
-            Encoder.h264(),
-            FrameRateControl.constant());
+    verifyHandBrakeCalled(unencodedVideo);
     assertThatTestDirectory()
         .containsExactly(
             unencodedVideo.originalPath(),
             unencodedVideo.tempEncodedPath(),
             unencodedVideo.encodedPath());
-  }
-
-  private StreamSubject assertThatTestDirectory() throws IOException {
-    return assertThat(Files.walk(testDirectory).filter(Files::isRegularFile));
   }
 
   private void whenHandBrakeReturns(boolean result) {
@@ -229,5 +203,19 @@ class VideoEncoderTest {
                   Files.copy(originalPath, tempEncodedPath);
                   return result;
                 });
+  }
+
+  private void verifyHandBrakeCalled(UnencodedVideo unencodedVideo) {
+    verify(mockHandBrake)
+        .encode(
+            Input.of(unencodedVideo.originalPath()),
+            Output.of(unencodedVideo.tempEncodedPath()),
+            Preset.productionStandard(),
+            Encoder.h264(),
+            FrameRateControl.constant());
+  }
+
+  private StreamSubject assertThatTestDirectory() throws IOException {
+    return assertThat(Files.walk(testDirectory).filter(Files::isRegularFile));
   }
 }


### PR DESCRIPTION
Yes - changing this behaviour once again!

Previously didn't overwrite the encoded file.

Did this to avoid data loss - basically wasn't confident the new encoded file would match the existing encoded file (e.g. if user encodes different source files but reuses the same file name (over different runs) - can't simply compare the source files because one of them would've been deleted).

Didn't realise I could just compare the temp file...

(Before https://github.com/will-molloy/auto-handbrake-encoding/commit/da19020495aa76575f65c5795112f8d3b49d9b3c it overwrote the encoded file regardless of the contents - did this back then because the archived files had a suffix to prevent re-encoding.)

Think this is the best of both: aborts encoding if data will be lost, otherwise continues (with warning).

This is desirable because previously if archiving failed, on the subsequent run the encoding would fail (since it refused to overwrite), then it wouldn't retry the failed archiving... quite annoying to the user who had to perform manual cleanup...