### PR TITLE
Fix flaky `JobQueueTest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
           distribution: corretto
           java-version: 21
 
-      - name: Build docker image
+      - name: Docker build
         run: |
           docker build -t handbrake-java-base -f base.Dockerfile .
           ./gradlew jibBuildTar
@@ -115,11 +115,15 @@ jobs:
           mkdir -p test-input test-output test-archive
           touch test-archive/.keep
           cp auto-handbrake-cfr/src/integrationTest/resources/Big_Buck_Bunny_360_10s_1MB.mp4 test-input/
+          
           docker run --rm -v $(pwd)/test-input:/input -v $(pwd)/test-output:/output -v $(pwd)/test-archive:/archive ghcr.io/will-molloy/auto-handbrake-cfr
+          
           # Verify encoded file was created in output directory
           ls test-output/*.cfr.mp4
+          
           # Verify original file was moved to archive directory
           ls test-archive/*.mp4
+          
           # Verify input directory is now empty
           [ -z "$(ls -A test-input)" ] || exit 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Load docker image
         run: docker load -i auto-handbrake-cfr/build/jib-image.tar
 
-      - name: Test docker image
+      - name: Smoke test
         run: |
           mkdir -p test-input test-output test-archive
           touch test-archive/.keep
@@ -124,7 +124,7 @@ jobs:
           [ -z "$(ls -A test-input)" ] || exit 1
 
   release:
-    needs: [ build, integration-test, smoke-test ]
+    needs: [ build, docker, integration-test, smoke-test ]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # auto-handbrake-encoding
 
-[![build](https://github.com/will-molloy/auto-handbrake-encoding/workflows/build/badge.svg?branch=main)](https://github.com/will-molloy/auto-handbrake-encoding/actions?query=workflow%3Abuild)
+[![build](https://github.com/will-molloy/auto-handbrake-encoding/actions/workflows/build.yml/badge.svg?branch=main&event=push)](https://github.com/will-molloy/auto-handbrake-encoding/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/will-molloy/auto-handbrake-encoding/branch/main/graph/badge.svg)](https://codecov.io/gh/will-molloy/auto-handbrake-encoding)
 
 Automating HandBrake encoding with Java

--- a/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/JobQueue.java
+++ b/auto-handbrake-cfr/src/main/java/com/willmolloy/handbrake/cfr/JobQueue.java
@@ -56,7 +56,7 @@ class JobQueue {
       }
     }
 
-    return Booleans.asList(results).stream().reduce(true, Boolean::logicalAnd);
+    return Booleans.asList(results).stream().allMatch(x -> x);
   }
 
   private Thread startJob(

--- a/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/JobQueueTest.java
+++ b/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/JobQueueTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
@@ -96,20 +95,20 @@ class JobQueueTest {
     }
   }
 
-  static Stream<Arguments> anyEncodeOrArchiveFailed() {
+  static Stream<boolean[]> anyEncodeOrArchiveFailed() {
     return Stream.of(
-        Arguments.of(true, true, false),
-        Arguments.of(true, false, true),
-        Arguments.of(false, true, true));
+        new boolean[] {true, true, false},
+        new boolean[] {true, false, true},
+        new boolean[] {false, true, true});
   }
 
   @ParameterizedTest
   @MethodSource("anyEncodeOrArchiveFailed")
   void
       whenEncodingFails_skipsArchiving_andStillEncodesAndArchivesOtherVideos_andReturnsFalseOverall(
-          boolean result1, boolean result2, boolean result3) throws Exception {
+          boolean[] encodeResults) throws Exception {
     // Given
-    whenVideoEncoderReturns(result1, result2, result3);
+    whenVideoEncoderReturns(encodeResults);
     when(mockVideoArchiver.archive(any())).thenReturn(true);
 
     Files.createDirectories(inputDirectory.resolve("NestedFolder"));
@@ -128,18 +127,19 @@ class JobQueueTest {
     for (UnencodedVideo video : videos) {
       verify(mockVideoEncoder).encode(same(video));
     }
-    verify(mockVideoArchiver, times(result1 ? 1 : 0)).archive(same(videos.get(0)));
-    verify(mockVideoArchiver, times(result2 ? 1 : 0)).archive(same(videos.get(1)));
-    verify(mockVideoArchiver, times(result3 ? 1 : 0)).archive(same(videos.get(2)));
+    verify(mockVideoArchiver, times(encodeResults[0] ? 1 : 0)).archive(same(videos.get(0)));
+    verify(mockVideoArchiver, times(encodeResults[1] ? 1 : 0)).archive(same(videos.get(1)));
+    verify(mockVideoArchiver, times(encodeResults[2] ? 1 : 0)).archive(same(videos.get(2)));
   }
 
   @ParameterizedTest
   @MethodSource("anyEncodeOrArchiveFailed")
   void whenArchivingFails_stillEncodesAndArchivesOtherVideos_andReturnsFalseOverall(
-      boolean result1, boolean result2, boolean result3) throws Exception {
+      boolean[] archiveResults) throws Exception {
     // Given
     whenVideoEncoderReturns(true);
-    when(mockVideoArchiver.archive(any())).thenReturn(result1, result2, result3);
+    when(mockVideoArchiver.archive(any()))
+        .thenReturn(archiveResults[0], archiveResults[1], archiveResults[2]);
 
     Files.createDirectories(inputDirectory.resolve("NestedFolder"));
 

--- a/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/JobQueueTest.java
+++ b/auto-handbrake-cfr/src/test/java/com/willmolloy/handbrake/cfr/JobQueueTest.java
@@ -16,7 +16,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.IntStream;
@@ -200,12 +199,13 @@ class JobQueueTest {
     when(mockVideoEncoder.encode(any()))
         .then(
             new Answer<Boolean>() {
-              final AtomicInteger i = new AtomicInteger();
+              int i;
 
               @Override
               public Boolean answer(InvocationOnMock invocation) {
+                boolean result = results[i++ % results.length];
                 lock.unlock();
-                return results[i.getAndIncrement() % results.length];
+                return result;
               }
             });
   }


### PR DESCRIPTION
Problem was race on `whenVideoEncoderReturns`, when `results` differ.

Interestingly the AI couldn't figure this out. It:
- Didn't reproduce the issue first, so tried random fixes
- Looked at the wrong test (`encodesInOrder`) and tried removing it
- Claimed there was a bug in `JobQueue` without evidence

You really have to prompt it properly or it does the most random bs.
