### PR TITLE
Clean up CI/CD: queue main builds, remove cleanup noise

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -184,13 +184,8 @@ jobs:
   cleanup:
     needs: [ smoke-test, release ]
     if: always()
-    concurrency:
-      group: cleanup-${{ github.run_id }}
-      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-
       - name: Cleanup artifacts
         uses: geekyeggo/delete-artifact@v5
         with:

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,15 +1,19 @@
-name: Dependency Submission
+name: dependency-submission
+run-name: dependency-submission by @${{ github.actor }}
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: [ main ]
 
-permissions:
-  contents: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   dependency-submission:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary
- Queue main builds instead of cancelling (`cancel-in-progress` conditional on event type)
- Remove no-op concurrency group from cleanup job (unique per run, does nothing)
- Remove unnecessary `actions/checkout` from cleanup job (`delete-artifact` doesn't need the repo)

## Test plan
- [ ] PR CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)