### PR TITLE
ci: switch to conventional commits for versioning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Bump version
         id: version
-        uses: paulhatch/semantic-version@v5.4.0
+        uses: paulhatch/semantic-version@v6.0.2
 
       - name: Download docker tar
         uses: actions/download-artifact@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
   cleanup:
     needs: [ smoke-test, release ]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Cleanup artifacts
         uses: geekyeggo/delete-artifact@v5

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,33 @@
+name: conventional-commits
+run-name: conventional-commits by @${{ github.actor }}
+
+on:
+  pull_request:
+    types: [ opened, reopened, edited, synchronize ]
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check-pr-title:
+    if: github.event_name == 'pull_request' && github.event.action != 'synchronize'
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  check-commits:
+    if: github.event_name == 'push' || github.event_name == 'pull_request' && github.event.action != 'edited'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: wagoid/commitlint-github-action@v6

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   dependency-submission:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Changes
- Bump [paulhatch/semantic-version](https://github.com/paulhatch/semantic-version) from v5.4.0 to v6.0.2, adopting its conventional-commit defaults (`feat:` = MINOR, `fix:` = PATCH, `!` suffix or `BREAKING CHANGE` footer = MAJOR)
- Add a `conventional-commits` workflow that checks PR titles ([amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request)) and commit messages ([wagoid/commitlint-github-action](https://github.com/wagoid/commitlint-github-action)) follow conventional commits
- Switch lightweight jobs (`cleanup`, `dependency-submission`) to `ubuntu-slim` via [gh-slimify](https://github.com/fchimpan/gh-slimify)
  - `build`/`integration-test` stay on `ubuntu-latest` (the actual gradle build/tests); `docker`/`release`/`smoke-test` stay since they use Docker